### PR TITLE
docs: CLAUDE.md 진행 상황 섹션 갱신

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,12 +11,17 @@ GitHub: `ofekim0/cheong-an` (Public, MIT)
 - 기존에 청년안심주택 전용 알림 서비스가 없어서 직접 만드는 프로젝트
 - 상세: `docs/PROJECT_PLAN.md`
 
-### 현재 진행 상황 (2026-04-15 기준)
+### 현재 진행 상황 (2026-05-19 기준)
 
 - **Phase 0 (프로젝트 셋업)**: 완료 — Next.js, ESLint, Vitest, CI/CD 구축
 - **Phase 1 Sprint 1 (크롤링 파이프라인)**: 진행 중
-  - 완료: 파서 레이어(`src/lib/crawler/` — `parseMainPage`, `parseDetailPage`, `checkBoardId` + 단위 테스트), `announcements` 테이블 마이그레이션(`supabase/migrations/00001_create_announcements.sql`), 타입 정의(`src/types/announcement.ts`), 학습 정리(`docs/learning/step4-crawling.md`)
-  - 잔여: ① 서비스 레이어(HTTP fetch + 재시도 + rate limit) ② 상세 페이지 검증 로직(`needsVerification` 실제 fetch) ③ Supabase 연동(저장 + `lastBoardId` 추적) ④ 스케줄러(Vercel Cron / GitHub Actions, 1시간 간격)
+  - 완료:
+    - 파서 레이어 (`parseMainPage`, `parseDetailPage`, `checkBoardId` + 단위 테스트)
+    - `announcements` 테이블 마이그레이션 (`supabase/migrations/00001_create_announcements.sql`), 타입 정의 (`src/types/announcement.ts`)
+    - 서비스 레이어 (`fetchHtml`, `retry`, `rateLimit`, `announcementService` + MSW 통합 테스트)
+    - 학습 정리 문서는 `docs/learning/` 하위 (`step4-crawling.md`, `step5-fetch-html.md`, `step5-retry.md`, `step5-rate-limit.md`, `step5-service-layer.md`, `step5-msw-testing.md`)
+  - 잔여: ① 상세 페이지 검증 로직(`needsVerification` 실제 fetch) ② Supabase 연동(저장 + `lastBoardId` 추적) ③ 스케줄러(Vercel Cron / GitHub Actions, 1시간 간격)
+  - 상세 진척과 인계 컨텍스트는 `HANDOFF.md` § 0 참고
 - **Phase 1 Sprint 2 (알림 시스템 + 기본 UI)**: 미착수
 
 ## 기술 스택


### PR DESCRIPTION
## Summary

PR #17 머지 결과를 `CLAUDE.md`의 \"현재 진행 상황\" 섹션에 반영. 새 세션이 CLAUDE.md(자동 주입)만 보고 출발해도 stale 정보로 헤매지 않도록 정리.

## 주요 변경 사항

### 1. `CLAUDE.md § 현재 진행 상황`

- 기준일 2026-04-15 → 2026-05-19
- Sprint 1 완료 항목에 서비스 레이어(`fetchHtml`, `retry`, `rateLimit`, `announcementService` + MSW 통합 테스트) 및 학습 정리 문서 6편 추가
- 잔여 항목 4개 → 3개로 축소: ① 상세 페이지 검증 ② Supabase 연동 ③ 스케줄러
- `HANDOFF.md § 0` 참고 안내 한 줄 추가

## 참고 사항

- 본 PR은 `1b42d75`(원래 PR #17 브랜치에 잘못 올라갔던 동일 변경)를 main 기반 새 브랜치에 cherry-pick한 결과. 원본 commit / 부활시켰던 `feat/crawler-service-layer` 원격 브랜치는 정리 완료.
- 코드 변경 없음, 문서 단일 파일 텍스트 갱신만.