### PR TITLE
feat: view.do 보강 fetch 도입 — JSON gap을 직접 호출해 누락 방지

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,6 @@ yarn-error.log*
 *.tsbuildinfo
 next-env.d.ts
 .envrc
+
+# claude code (local, may contain secrets)
+.claude/settings.local.json

--- a/src/lib/crawler/__fixtures__/detailPage.html
+++ b/src/lib/crawler/__fixtures__/detailPage.html
@@ -1,69 +1,919 @@
-<div class="board_view">
-  <div class="view_info">
-    <p class="subject">[민간임대] 태릉입구역 이니티움 추가모집공고</p>
-    <ul class="view_data">
-      <li><span class="title">담당부서/사업자</span>유한책임회사 문하</li>
-      <li><span class="title">공고게시일</span>2026-03-26</li>
-      <li><span class="title">청약신청일</span>2026-03-30</li>
-    </ul>
-    <ul class="view_data">
-      <li><span class="title">카테고리</span>
-        <option value="01">  </option>
-        <option value="02">  </option>
-        <option value="03">  </option>
-        <option value="04">  </option>
-        <option value="05">  </option>
-        <option value="06">  </option>
-        <option value="07">  </option>
-        <option value="08">  </option>
-        <option value="09"> 노원구 </option>
-        <option value="10">  </option>
-        <option value="11">  </option>
-        <option value="12">  </option>
-        <option value="13">  </option>
-        <option value="14">  </option>
-        <option value="15">  </option>
-        <option value="16">  </option>
-        <option value="17">  </option>
-        <option value="18">  </option>
-        <option value="19">  </option>
-        <option value="20">  </option>
-        <option value="21">  </option>
-        <option value="22">  </option>
-        <option value="23">  </option>
-        <option value="24">  </option>
-        <option value="25">  </option>
-      </li>
-    </ul>
-    <ul class="view_data">
-      <li>
-        <span class="title">첨부파일</span>
-        <span class="file">
-          <span class="file">
-            <a style="display: inline-block !important; margin-bottom:5px;" href="/coHouse/cmmn/file/fileDown.do?atchFileId=4917abcabf9c4f1ba9d16acbad42c209&fileSn=1">민간_260326_태릉입구역_이니티움_청년안심주택 추가모집공고문.pdf</a>
-          </span>
-        </span>
-      </li>
-    </ul>
-  </div>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+	
+		
+		
+		
+		
+		
+	
+
+	
+		
+		
+		
+		
+		
+	
+
+
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width,user-scalable=yes,initial-scale=1.0,maximum-scale=10,minimum-scale=1.0">
+
+	<meta name="description" content="청년안심주택">
+	<meta name="Keyword" content="청년안심주택">
+	<meta property="og:site_name" content="청년안심주택">
+	
+	<meta property="og:type" content="website">
+	<meta property="og:title" content="청년안심주택">
+	<meta property="og:description" content="청년안심주택">
+	<meta property="og:Keyword" content="청년안심주택">
+	<meta property="og:url" content="https://soco.seoul.go.kr/youth/main/main.do">
+	<meta property="og:url" content="">
+	
+	<link rel="stylesheet" href="/resources/common/css/reset.css">
+    <link rel="stylesheet" href="/resources/youth/css/style.css">
+    <link rel="stylesheet" href="/resources/youth/css/sub_style.css">
+    <link rel="stylesheet" href="/resources/youth/css/bbs.css">
+    <link rel="stylesheet" type="text/css" href="/resources/youth/css/slick.css">
+    <link rel="stylesheet" href="/resources/youth/css/responsive.css">
+    <link rel="stylesheet" href="/resources/youth/css/jquery-ui.min.css">
+    <link rel="stylesheet" href="/resources/youth/css/bootstrap-datepicker.css">
+    <link rel="shortcut icon" type="image/x-icon" href="/resources/youth/img/main/favicon.ico">
+
+    <title>모집공고 | 주택찾기 | </title>
+
+    <script async src="//www.googletagmanager.com/gtag/js?id=UA-222727054-1"></script>
+	<script>
+		window.dataLayer = window.dataLayer || [];
+		function gtag(){dataLayer.push(arguments);}
+		gtag('js', new Date());
+		gtag('config', 'UA-222727054-1');
+	</script>
+	<script src="https://developers.kakao.com/sdk/js/kakao.js"></script>
+	<script src="https://www.seoul.go.kr/seoulgnb/gnb.js"></script>
+    <script src="/resources/youth/js/jquery-3.6.0.min.js"></script>
+    <script src="/resources/youth/js/jquery-ui.min.js"></script>
+    <!-- <script src="/resources/youth/js/bootstrap-datepicker.js"></script> -->
+    <script src="/resources/youth/js/slick.min.js"></script>
+    <script src="/resources/youth/js/main.js"></script>
+
+	<script src="/resources/common/js/address.js?dt=20211115"></script>
+	<script src="//t1.daumcdn.net/mapjsapi/bundle/postcode/prod/postcode.v2.js"></script>
+	<!--<script type="text/javascript" src="https://openapi.map.naver.com/openapi/v3/maps.js?&amp;submodules=panorama,geocoder,drawing,visualization"></script>-->
+	<!--<script src="https://oapi.map.naver.com/openapi/v3/maps.js?ncpKeyId="></script>-->
+ 	
+	<script src="/cheditor/cheditor.js"></script>
+</head>
+<body> 
+<section id="wrap">
+	<dl class="accessibilityWrap">
+		<dt class="hide"><strong>바로가기 메뉴</strong></dt>
+		<dd><a href="#cont">본문 바로가기</a></dd>
+		<dd><a href="#top_nav">주메뉴 바로가기</a></dd>
+	</dl>
+	<div id='seoul-common-gnb'></div>
+	<script type="application/ld+json">
+{
+ "@context": "http://schema.org",
+ "@type": "Organizaion",
+ "name": "청년안심주택",
+ "url": "https://soco.seoul.go.kr",
+ "sameAs": [
+   "https://blog.naver.com/seoul_youth_house",
+   "https://www.facebook.com/2030.house",
+   "https://www.instagram.com/seoul_youth_house/?hl=ko"
+ ]
+} 
+</script>
+
+  <script>
+		(function() {
+		    // 검사할 변수 이름
+		    var paramName = 'searchKeyword';
+		
+		    // 전역 객체/쿼리스트링에서 값 가져오기
+		    var value = window[paramName] || new URLSearchParams(window.location.search).get(paramName);
+		
+		    if (value) {
+		        // XSS 위험 요소 제거
+		        value = value.replace(/<script.*?>.*?<\/script>/gi, '')  // 스크립트 태그 제거
+		                     .replace(/<\/?[^>]+(>|$)/g, '')              // 모든 HTML 태그 제거
+		                     .replace(/["']/g, '');                       // 따옴표 제거
+		        window[paramName] = value; // 안전한 값으로 덮어쓰기
+		    }
+		})();
+		</script>
+<div class="header">
+<span class="top_bg"></span>
+	<div class="topWrap">
+		<!-- 로고 -->
+		<h1 class="topLogo">
+			<a href="/youth/main/main.do"><span class="hide">청년안심주택</span></a>
+        </h1>
+		<!-- 메인메뉴 -->
+		<nav id="top_nav" class="mainNav">
+			<ul class="depth1">
+				<li><a href="/youth/main/contents.do?menuNo=400012" >청년안심주택?</a>
+	
+							<ul class="depth2">
+									<li>
+											<a href="/youth/main/contents.do?menuNo=400012" title="사업소개 페이지이동" class="" >사업소개</a>
+												</li>
+									<li>
+											<a href="/youth/main/contents.do?menuNo=400013" title="센터소개 페이지이동" class="" >센터소개</a>
+												</li>
+									<li>
+											<a href="/youth/main/contents.do?menuNo=400014" title="공급현황 및 계획 페이지이동" class="" >공급현황 및 계획</a>
+												</li>
+									<li>
+											<a href="/youth/pgm/home/yohome/supportYouth1.do?menuNo=400039" title="입주자격안내 페이지이동" class="" >입주자격안내</a>
+												</li>
+									<li>
+											<a href="/youth/main/contents.do?menuNo=400010" title="입주신청절차 페이지이동" class="" >입주신청절차</a>
+												</li>
+									</ul>
+							</li>
+					<li><a href="/youth/pgm/home/yohome/list.do?menuNo=400002" >주택찾기</a>
+	
+							<ul class="depth2">
+									<li>
+											<a href="/youth/pgm/home/yohome/list.do?menuNo=400002" title="단지별 정보 페이지이동" class="" >단지별 정보</a>
+												</li>
+									<li>
+											<a href="/youth/bbs/BMSR00015/list.do?menuNo=400008" title="모집공고 페이지이동" class="active" >모집공고</a>
+												</li>
+									<li>
+											<a href="/youth/pgm/home/yohome/compareSearchList.do?menuNo=400040" title="단지비교검색 페이지이동" class="" >단지비교검색</a>
+												</li>
+									</ul>
+							</li>
+					<li><a href="/youth/main/contents.do?menuNo=400016" >금융지원</a>
+	
+							<ul class="depth2">
+									<li>
+											<a href="/youth/main/contents.do?menuNo=400021" title="금융지원 안내 페이지이동" class="" >금융지원 안내</a>
+												</li>
+									<li>
+											<a href="/youth/main/contents.do?menuNo=400023" title="신혼부부 임차보증금 이자지원 페이지이동" class="" >신혼부부 임차보증금 이자지원</a>
+												</li>
+									<li>
+											<a href="/youth/main/contents.do?menuNo=400024" title="청년 임차보증금 이자지원 페이지이동" class="" >청년 임차보증금 이자지원</a>
+												</li>
+									<li>
+											<a href="/youth/main/contents.do?menuNo=400025" title="서울시 청년월세지원 페이지이동" class="" >서울시 청년월세지원</a>
+												</li>
+									</ul>
+							</li>
+					<li><a href="/youth/bbs/BMSR00013/list.do?menuNo=400018" >고객센터</a>
+	
+							<ul class="depth2">
+									<li>
+											<a href="/youth/bbs/BMSR00013/list.do?menuNo=400018" title="공지사항 페이지이동" class="" >공지사항</a>
+												</li>
+									</ul>
+							</li>
+					</ul>
+		</nav><!-- /Top Nav end -->
+
+		<!-- 사이드메뉴 -->
+		<div class="mainGNB pc_only">
+			<a href="/youth/member-login/login.do?menuNo=400029" class="gnb_login">로그인</a>
+			<button class="gnb_menu btn_menu"><span>메뉴</span></button>
+		</div>
+		<button class="gnb_menu btn_menu tablet"><span>메뉴</span></button>
+
+	</div><!-- /topWrap end -->
 </div>
-<div class="board_cont">
-  <p>태릉입구역 이니티움 청년안심주택 입주자 추가모집공고문(공공지원민간임대)을 붙임과 같이 게시합니다.</p>
-  <p>자세한 내용은 첨부파일의 모집공고문을 확인하시기 바랍니다.</p>
-  <p><b style="font-size: 20px;">[단지개요]</b></p>
-  <p>■단지명 : 태릉입구역 이니티움</p>
-  <p>■주택위치 : 서울특별시 노원구 공릉동 684-41 (6, 7호선 태릉입구역 1번 출구)</p>
-  <p>■공급호수 : 총 100세대 중 금회 추가모집 공공지원민간임대 1세대 (일반공급 1세대)</p>
-  <p>■사업주체 : 유한책임회사 문하</p>
-  <p>■시공사 : 삼정건설산업(주)</p>
-  <h2><span style="font-size: 20px;">[공급일정]</span></h2>
-  <p>■모집공고 : '26. 03. 26. (목)</p>
-  <p><span style="color: #ff00ff;"><b>■청약신청 : '26. 03. 30. (월) 09:00 ~ 03. 31. (화) 17:00</b></span></p>
-  <p>■서류심사 대상자 발표 : '26. 04. 01. (수) 17:00</p>
-  <p>■서류사본제출(이메일) : '26. 04. 04. (토) 17:00</p>
-  <p>■계약체결 및 원본서류제출 : '26. 04. 12. (일)</p>
-  <h2><span style="font-size: 20px;">[청약신청]</span></h2>
-  <p>■ 청약신청 페이지 : <a href="https://mhinitium.co.kr/" target="_blank">https://mhinitium.co.kr</a></p>
-  <p>■ 문의전화 : 070-4098-0123</p>
-  <p>■ 운영시간 : 월 ~ 금 10:00~18:00 (점심시간 : 13:00~14:00)</p>
+
+<div class="mobileNav">
+	<div class="top">
+		<div class="moLogo">
+			<a href="/youth/main/main.do"><span class="hide">청년안심주택</span></a>
+			<button class="close btn_menu active"><span>닫기</span></button>
+		</div>
+		<ul class="etc">
+			<li>
+				<a href="/youth/member-login/login.do?menuNo=400029" class="gnb_login">로그인</a>
+				</li>
+			<li>
+				<a href="/youth/member-join/joinType.do?menuNo=400031">회원가입</a>
+				</li>
+		</ul>
+	</div>
+	<ul class="lnb_m">
+		<li>
+		<a href="/youth/main/contents.do?menuNo=400012" >청년안심주택?<span>more</span></a>
+
+		<ul class="depth">
+				<li>
+					<a href="/youth/main/contents.do?menuNo=400012" title="사업소개 페이지이동" class="" >사업소개</a>
+					</li>
+			<li>
+					<a href="/youth/main/contents.do?menuNo=400013" title="센터소개 페이지이동" class="" >센터소개</a>
+					</li>
+			<li>
+					<a href="/youth/main/contents.do?menuNo=400014" title="공급현황 및 계획 페이지이동" class="" >공급현황 및 계획</a>
+					</li>
+			<li>
+					<a href="/youth/pgm/home/yohome/supportYouth1.do?menuNo=400039" title="입주자격안내 페이지이동" class="" >입주자격안내</a>
+					</li>
+			<li>
+					<a href="/youth/main/contents.do?menuNo=400010" title="입주신청절차 페이지이동" class="" >입주신청절차</a>
+					</li>
+			</ul>
+		</li>
+		<li>
+		<a href="/youth/pgm/home/yohome/list.do?menuNo=400002" >주택찾기<span>more</span></a>
+
+		<ul class="depth">
+				<li>
+					<a href="/youth/pgm/home/yohome/list.do?menuNo=400002" title="단지별 정보 페이지이동" class="" >단지별 정보</a>
+					</li>
+			<li>
+					<a href="/youth/bbs/BMSR00015/list.do?menuNo=400008" title="모집공고 페이지이동" class="active" >모집공고</a>
+					</li>
+			<li>
+					<a href="/youth/pgm/home/yohome/compareSearchList.do?menuNo=400040" title="단지비교검색 페이지이동" class="" >단지비교검색</a>
+					</li>
+			</ul>
+		</li>
+		<li>
+		<a href="/youth/main/contents.do?menuNo=400016" >금융지원<span>more</span></a>
+
+		<ul class="depth">
+				<li>
+					<a href="/youth/main/contents.do?menuNo=400021" title="금융지원 안내 페이지이동" class="" >금융지원 안내</a>
+					</li>
+			<li>
+					<a href="/youth/main/contents.do?menuNo=400023" title="신혼부부 임차보증금 이자지원 페이지이동" class="" >신혼부부 임차보증금 이자지원</a>
+					</li>
+			<li>
+					<a href="/youth/main/contents.do?menuNo=400024" title="청년 임차보증금 이자지원 페이지이동" class="" >청년 임차보증금 이자지원</a>
+					</li>
+			<li>
+					<a href="/youth/main/contents.do?menuNo=400025" title="서울시 청년월세지원 페이지이동" class="" >서울시 청년월세지원</a>
+					</li>
+			</ul>
+		</li>
+		<li>
+		<a href="/youth/bbs/BMSR00013/list.do?menuNo=400018" >고객센터<span>more</span></a>
+
+		<ul class="depth">
+				<li>
+					<a href="/youth/bbs/BMSR00013/list.do?menuNo=400018" title="공지사항 페이지이동" class="" >공지사항</a>
+					</li>
+			</ul>
+		</li>
+		<li>
+		<a href="/youth/member-login/login.do?menuNo=400030" >회원<span>more</span></a>
+
+		<ul class="depth">
+				<li>
+					<a href="/youth/member-login/login.do?menuNo=400030" title="로그인 페이지이동" class="" >로그인</a>
+					</li>
+			<li>
+					<a href="/youth/member-join/joinType.do?menuNo=400031" title="회원가입 페이지이동" class="" >회원가입</a>
+					</li>
+			<li>
+					<a href="/youth/member-search/searchId.do?menuNo=400032" title="아이디찾기 페이지이동" class="" >아이디찾기</a>
+					</li>
+			<li>
+					<a href="/youth/member-search/searchPwdByHint.do?menuNo=400034" title="비밀번호찾기 페이지이동" class="" >비밀번호찾기</a>
+					</li>
+			<li>
+					<a href="/youth/main/contents.do?menuNo=400036" title="개인정보처리방침 페이지이동" class="" >개인정보처리방침</a>
+					</li>
+			</ul>
+		</li>
+		<li>
+		<a href="/youth/mypage/myInfo.do?menuNo=400035" >마이페이지<span>more</span></a>
+
+		</li>
+		</ul>
 </div>
+<div class="mobileNav_bg popBg"></div>
+
+<div class="sitemap">
+	<div class="sitemap-side">
+		<p>SITEMAP</p>
+	</div>
+	<div class="sitemap-cont">
+	    <h1 class="tit">사이트맵</h1>
+		<ul class="menu">
+			<li>
+				<p class="depth1">청년안심주택?</p>
+				<ul class="depth2">
+						<li>
+								<a href="/youth/main/contents.do?menuNo=400012" title="사업소개 페이지이동" class="" >사업소개</a>
+									</li>
+						<li>
+								<a href="/youth/main/contents.do?menuNo=400013" title="센터소개 페이지이동" class="" >센터소개</a>
+									</li>
+						<li>
+								<a href="/youth/main/contents.do?menuNo=400014" title="공급현황 및 계획 페이지이동" class="" >공급현황 및 계획</a>
+									</li>
+						<li>
+								<a href="/youth/pgm/home/yohome/supportYouth1.do?menuNo=400039" title="입주자격안내 페이지이동" class="" >입주자격안내</a>
+									</li>
+						<li>
+								<a href="/youth/main/contents.do?menuNo=400010" title="입주신청절차 페이지이동" class="" >입주신청절차</a>
+									</li>
+						</ul>
+				</li>
+			<li>
+				<p class="depth1">주택찾기</p>
+				<ul class="depth2">
+						<li>
+								<a href="/youth/pgm/home/yohome/list.do?menuNo=400002" title="단지별 정보 페이지이동" class="" >단지별 정보</a>
+									</li>
+						<li>
+								<a href="/youth/bbs/BMSR00015/list.do?menuNo=400008" title="모집공고 페이지이동" class="active" >모집공고</a>
+									</li>
+						<li>
+								<a href="/youth/pgm/home/yohome/compareSearchList.do?menuNo=400040" title="단지비교검색 페이지이동" class="" >단지비교검색</a>
+									</li>
+						</ul>
+				</li>
+			<li>
+				<p class="depth1">금융지원</p>
+				<ul class="depth2">
+						<li>
+								<a href="/youth/main/contents.do?menuNo=400021" title="금융지원 안내 페이지이동" class="" >금융지원 안내</a>
+									</li>
+						<li>
+								<a href="/youth/main/contents.do?menuNo=400023" title="신혼부부 임차보증금 이자지원 페이지이동" class="" >신혼부부 임차보증금 이자지원</a>
+									</li>
+						<li>
+								<a href="/youth/main/contents.do?menuNo=400024" title="청년 임차보증금 이자지원 페이지이동" class="" >청년 임차보증금 이자지원</a>
+									</li>
+						<li>
+								<a href="/youth/main/contents.do?menuNo=400025" title="서울시 청년월세지원 페이지이동" class="" >서울시 청년월세지원</a>
+									</li>
+						</ul>
+				</li>
+			<li>
+				<p class="depth1">고객센터</p>
+				<ul class="depth2">
+						<li>
+								<a href="/youth/bbs/BMSR00013/list.do?menuNo=400018" title="공지사항 페이지이동" class="" >공지사항</a>
+									</li>
+						</ul>
+				</li>
+			<li>
+				<p class="depth1">회원</p>
+				<ul class="depth2">
+						<li>
+								<a href="/youth/member-login/login.do?menuNo=400030" title="로그인 페이지이동" class="" >로그인</a>
+									</li>
+						<li>
+								<a href="/youth/member-join/joinType.do?menuNo=400031" title="회원가입 페이지이동" class="" >회원가입</a>
+									</li>
+						<li>
+								<a href="/youth/member-search/searchId.do?menuNo=400032" title="아이디찾기 페이지이동" class="" >아이디찾기</a>
+									</li>
+						<li>
+								<a href="/youth/member-search/searchPwdByHint.do?menuNo=400034" title="비밀번호찾기 페이지이동" class="" >비밀번호찾기</a>
+									</li>
+						<li>
+								<a href="/youth/main/contents.do?menuNo=400036" title="개인정보처리방침 페이지이동" class="" >개인정보처리방침</a>
+									</li>
+						</ul>
+				</li>
+			<li>
+				<p class="depth1">마이페이지</p>
+				</li>
+			</ul>
+		<button type="button" class="sitemap-close">닫기</button>
+	</div>
+</div>
+<div id="cont">
+
+
+   	
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+<div class="location">
+    <ul class="inner">
+
+        <li class="home"><a href="/youth/main/main.do">메인으로 이동</a></li>
+         <!-- 로그인 O  -->
+		
+		
+		<!-- 로그인 X  -->
+		
+        
+        <li class="location__menu">
+            <a href="#" title="주택찾기 페이지 이동">주택찾기</a>
+            <ul class="sub">
+              
+			  <li><a href="/youth/main/contents.do?menuNo=400012"  title="청년안심주택? 페이지 이동">청년안심주택?</a></li>
+			  
+			  <li><a href="/youth/pgm/home/yohome/list.do?menuNo=400002"  title="주택찾기 페이지 이동">주택찾기</a></li>
+			  
+			  <li><a href="/youth/main/contents.do?menuNo=400016"  title="금융지원 페이지 이동">금융지원</a></li>
+			  
+			  <li><a href="/youth/bbs/BMSR00013/list.do?menuNo=400018"  title="고객센터 페이지 이동">고객센터</a></li>
+			  
+			  <li><a href="/youth/member-login/login.do?menuNo=400030"  title="회원 페이지 이동">회원</a></li>
+			  
+			  <li><a href="/youth/mypage/myInfo.do?menuNo=400035"  title="마이페이지 페이지 이동">마이페이지</a></li>
+			  
+            </ul>
+        </li>
+        
+        
+			<li class="location__menu depth">
+				<a href="#" title="모집공고 페이지 이동">모집공고</a>
+				<ul class="sub">
+					
+						<li><a href="/youth/pgm/home/yohome/list.do?menuNo=400002"  title="단지별 정보 페이지 이동">단지별 정보</a></li>
+					
+						<li><a href="/youth/bbs/BMSR00015/list.do?menuNo=400008"  title="모집공고 페이지 이동">모집공고</a></li>
+					
+						<li><a href="/youth/pgm/home/yohome/compareSearchList.do?menuNo=400040"  title="단지비교검색 페이지 이동">단지비교검색</a></li>
+					
+				</ul>
+			</li>
+		
+		
+
+        <li class="location__quick print">
+			<button type="button" class="btn_sub btn_print" onclick="window.print();">인쇄하기</button>
+        </li>
+        <li class="location__quick share">
+        	<ul class="share__depth">
+    			<li class="share__btn"><button type="button" title="공유하기 열기"><span class="hide">공유하기</span></button></li>
+    			<li class="share__sns facebook"><button type="button" title="새 창 열림"><span class="hide">페이스북 공유하기</span></button></li>
+    			<li class="share__sns blog"><button type="button" title="새 창 열림"><span class="hide">네이버 블로그 공유하기</span></button></li>
+    			<li class="share__sns kakao"><button type="button" title="새 창 열림"><span class="hide">카카오톡 공유하기</span></button></li>
+        	</ul>
+        </li>
+    </ul>
+</div>
+
+<script>
+/*공유하기*/
+function copyClip(url){
+	var $temp = $('<input>');
+	$('body').append($temp);
+	$temp.val(url).select();
+	document.execCommand('copy');
+	$temp.remove();
+	alert('URL이 복사되었습니다.');
+}
+
+
+$('.share__depth .blog button').click(function(event) {
+	event.preventDefault();
+	var url = "http://share.naver.com/web/shareView.nhn?url=" + titl + "&url=" + link;
+	windowOpen (url, 800, 400, 'yes');
+});
+$('.share__depth .facebook button').click(function(event) {
+	event.preventDefault();
+	var url = "http://www.facebook.com/sharer.php?u=" + link + "&t=" + titl;
+	windowOpen (url, 900, 450, 'no');
+});
+
+/* kakao */
+titl = document.title;
+titl = titl.replace (/'/gi,"´");
+titl = titl.replace (/"/gi,"˝");
+titl = encodeURIComponent(titl);
+var link = encodeURIComponent(location.href);
+
+Kakao.init('fdf749c4279e809040327b7d30163614');
+console.log(Kakao.isInitialized());
+
+$('.share__depth .kakao button').click(function(event) {
+	Kakao.Link.sendDefault({
+		objectType: 'feed',
+		content: {
+			title: '청년안심주택',
+			description: '청년안심주택',
+			imageUrl: encodeURIComponent(window.location.href) + '/resources/common/img/shareImg_yo.png',
+			link: {
+				mobileWebUrl: window.location.href,
+				webUrl: window.location.href
+			}
+		},
+		buttons: [
+		{
+			title: '상세보기',
+			link: {
+				mobileWebUrl: window.location.href,
+				webUrl: window.location.href
+			}
+		}]
+	});
+});
+
+function windowOpen () {
+	var nUrl;
+	var nWidth;
+	var nHeight;
+	var nLeft;
+	var nTop;
+	var nScroll;
+
+	nUrl = arguments[0];
+	nWidth = arguments[1];
+	nHeight = arguments[2];
+	nScroll = (arguments.length > 3 ? arguments[3] : "no");
+	nLeft = (arguments.length > 4 ? arguments[4] : (screen.width/2 - nWidth/2));
+	nTop = (arguments.length > 5 ? arguments[5] : (screen.height/2 - nHeight/2));
+
+	winopen=window.open(nUrl, 'sns_win', "left="+nLeft+",top="+nTop+",width="+nWidth+",height="+nHeight+",scrollbars="+nScroll+",toolbar=no,location=no,directories=no,status=no,menubar=no,resizable=no");
+}
+</script>
+
+    <div class="subpage_content" id="printArea">
+		
+		
+		
+			
+			
+			
+		
+		
+			
+
+
+
+
+
+<script>
+$(document).ready(function() {
+    // Your code goes here
+    var a = $('#optn1').val();
+    var b ="2026-05-14";
+    var c ="2026-05-14";
+    console.log(a);
+    console.log(b);
+    console.log(c);
+});
+function doDel(){
+	if (confirm("삭제 하시겠습니까?")) {
+		var form = document.createFrm;
+		form.action = "delete.do";
+		form.submit();
+	}
+}
+
+
+</script>
+
+<div class="subpage_content">
+	<div class="layout">
+		<div class="board_view">
+			<div class="view_info">
+				<p class="subject">[민간임대] 태릉입구역 와이엔타워 추가모집공고</p>
+				<ul class="view_data">
+					<li><span class="title">담당부서/사업자</span>태운산업개발(주)</li>
+					<li><span class="title">공고게시일</span>2026-05-14</li>
+					<li><span class="title">청약신청일</span>2026-05-18</li>
+				</ul>
+				<ul class="view_data">
+				<li><span class="title">카테고리</span>
+					
+						<option value="01">  </option>
+					
+						<option value="02">  </option>
+					
+						<option value="03">  </option>
+					
+						<option value="04">  </option>
+					
+						<option value="05">  </option>
+					
+						<option value="06">  </option>
+					
+						<option value="07">  </option>
+					
+						<option value="08">  </option>
+					
+						<option value="09"> 노원구 </option>
+					
+						<option value="10">  </option>
+					
+						<option value="11">  </option>
+					
+						<option value="12">  </option>
+					
+						<option value="13">  </option>
+					
+						<option value="14">  </option>
+					
+						<option value="15">  </option>
+					
+						<option value="16">  </option>
+					
+						<option value="17">  </option>
+					
+						<option value="18">  </option>
+					
+						<option value="19">  </option>
+					
+						<option value="20">  </option>
+					
+						<option value="21">  </option>
+					
+						<option value="22">  </option>
+					
+						<option value="23">  </option>
+					
+						<option value="24">  </option>
+					
+						<option value="25">  </option>
+					
+				</li>
+				</ul> 
+				<ul class="view_data">
+					<li>
+						<span class="title">첨부파일</span>
+						<span class="file">
+							
+							<span class="file">
+								
+									<a style="display: inline-block !important; margin-bottom:5px;" href="/coHouse/cmmn/file/fileDown.do?atchFileId=5f6e0d6f9a9748fca37ed0bb2b949ff5&fileSn=1"  >민간_260514_태릉입구역_와이엔타워_청년안심주택 추가모집공고문.pdf</a>
+									
+									<a style="display: inline-block !important; margin-bottom:5px;" href="javascript:void(0);" onclick="previewAjax('/coHouse/cmmn/file/fileDown.do?atchFileId=5f6e0d6f9a9748fca37ed0bb2b949ff5&fileSn=1','민간_260514_태릉입구역_와이엔타워_청년안심주택 추가모집공고문.pdf')" title="바로보기 – 새 창">
+									<img src="https://viewstory.net/resources/preview/image/common/view_icon.png" alt="바로보기 버튼" />
+									</a>
+									<a style="display: inline-block !important; margin-bottom:5px;" href="javascript:void(0);" onclick="preListen('/coHouse/cmmn/file/fileDown.do?atchFileId=5f6e0d6f9a9748fca37ed0bb2b949ff5&fileSn=1','민간_260514_태릉입구역_와이엔타워_청년안심주택 추가모집공고문.pdf')" title="바로듣기 – 새 창">
+									<img src="https://viewstory.net/resources/preview/image/common/speaker_icon.png" alt="바로듣기 버튼" />
+									</a>
+								
+							</span>
+						
+						</span>
+					</li>
+				</ul>
+			</div>
+		</div><!-- board_view -->
+		<div class="board_cont"><p style="padding: 0px; box-sizing: border-box; letter-spacing: -1px; color: #333333; font-family: NanumSquareOTF_ac; font-size: medium;">태릉입구역 와이엔타워 청년안심주택 입주자 추가모집공고문(공공지원민간임대)을 붙임과 같이 게시합니다.&nbsp;</p>
+<p><span style="color: #333333; font-family: NanumSquareOTF_ac; font-size: medium; letter-spacing: -1px; margin: 0px; padding: 0px; box-sizing: border-box;">자세한 내용은 첨부파일의 모집공고문을 확인하시기 바랍니다.</span></p>
+<p><span style="color: #333333; font-family: NanumSquareOTF_ac; font-size: medium; letter-spacing: -1px;"></span></p>
+<h2 style="margin: 0px; padding: 0px; box-sizing: border-box; letter-spacing: -1px; color: #333333; font-family: nanumsquareotf_ac;"><span style="font-size: 18px;"></span></h2>
+<p style="padding: 0px; box-sizing: border-box; letter-spacing: -1px; color: #333333; font-family: NanumSquareOTF_ac; font-size: medium;">&nbsp;</p>
+<p style="padding: 0px; box-sizing: border-box; letter-spacing: -1px; color: #333333; font-family: NanumSquareOTF_ac; font-size: medium;"><b style="margin: 0px; padding: 0px; box-sizing: border-box; font-size: 20px;">[단지개요]</b></p>
+<p style="padding: 0px; box-sizing: border-box; letter-spacing: -1px; color: #333333; font-family: NanumSquareOTF_ac; font-size: medium;"></p>
+<p style="padding: 0px; box-sizing: border-box; letter-spacing: -1px; color: #333333; font-family: NanumSquareOTF_ac; font-size: medium;"></p>
+<p style="padding: 0px; box-sizing: border-box; letter-spacing: -1px; color: #333333; font-family: NanumSquareOTF_ac; font-size: medium;">■단지명 : 와이엔타워</p>
+<p style="padding: 0px; box-sizing: border-box; letter-spacing: -1px; color: #333333; font-family: NanumSquareOTF_ac; font-size: medium;">■주택위치 : 서울특별시 노원구 동일로 1000 (6, 7호선 태릉입구역 4번 출구)</p>
+<p style="padding: 0px; box-sizing: border-box; letter-spacing: -1px; color: #333333; font-family: NanumSquareOTF_ac; font-size: medium;">■공급호수 : 총 195세대 중 금회 추가모집 공공지원민간임대&nbsp; 예비자 모집</p>
+<p style="padding: 0px; box-sizing: border-box; letter-spacing: -1px; color: #333333; font-family: NanumSquareOTF_ac; font-size: medium;"></p>
+<p style="padding: 0px; box-sizing: border-box; letter-spacing: -1px; color: #333333; font-family: NanumSquareOTF_ac; font-size: medium;"></p>
+<p style="padding: 0px; box-sizing: border-box; letter-spacing: -1px; color: #333333; font-family: NanumSquareOTF_ac; font-size: medium;">■사업주체 : 태운산업개발㈜</p>
+<p style="padding: 0px; box-sizing: border-box; letter-spacing: -1px; color: #333333; font-family: NanumSquareOTF_ac; font-size: medium;">■시공사 : 한양산업개발㈜</p>
+<p style="padding: 0px; box-sizing: border-box; letter-spacing: -1px; color: #333333; font-family: NanumSquareOTF_ac; font-size: medium;">&nbsp; &nbsp;</p>
+<h2 style="margin: 0px; padding: 0px; box-sizing: border-box; letter-spacing: -1px; color: #333333; font-family: nanumsquareotf_ac;"><span style="font-size: 20px;">[공급일정]</span></h2>
+<p style="padding: 0px; box-sizing: border-box; letter-spacing: -1px; color: #333333; font-family: NanumSquareOTF_ac; font-size: medium;">■모집공고 : ‘26. 05. 14. (목)</p>
+<p style="padding: 0px; box-sizing: border-box;"><span style="letter-spacing: -1px; font-family: nanumsquareotf_ac; font-size: medium; color: #ff00ff;"><b>■청약신청 : ‘26. 05. 18. (월) 09:00 ~ 23:00</b></span></p>
+<p style="padding: 0px; box-sizing: border-box;"><span style="letter-spacing: -1px; color: #333333; font-family: NanumSquareOTF_ac; font-size: medium;">■서류심사 대상자 발표 :&nbsp;</span><span style="color: #333333; font-family: NanumSquareOTF_ac; font-size: medium; letter-spacing: -1px;">‘26. 05. 26. (화) 17:00</span></p>
+<p style="padding: 0px; box-sizing: border-box;"><span style="color: #333333; font-family: NanumSquareOTF_ac; font-size: medium; letter-spacing: -1px;">■계약체결 및 원본서류제출 : 공실 발생 시 순번대로 연락</span></p>
+<p style="padding: 0px; box-sizing: border-box;"><span style="color: #333333; font-family: NanumSquareOTF_ac; font-size: medium; letter-spacing: -1px;">&nbsp;</span></p>
+<h2 style="margin: 0px; padding: 0px; box-sizing: border-box; letter-spacing: -1px; color: #333333; font-family: nanumsquareotf_ac;"><span style="font-size: 20px;">[청약신청]</span></h2>
+<p style="padding: 0px; box-sizing: border-box; letter-spacing: -1px; color: #333333; font-family: NanumSquareOTF_ac; font-size: medium;">■ 청약신청 페이지 : <b><span style="color: #0000ff;"><a href="https://naver.me/GCJukbU2" target="_blank" title="와이엔타워 추가모집 신청"><span style="color: #0000ff;">https://naver.me/GCJukbU2</span></a></span></b></p>
+<p style="padding: 0px; box-sizing: border-box; letter-spacing: -1px; color: #333333; font-family: NanumSquareOTF_ac; font-size: medium;">■ 문의전화 : 02-449-7425</p>
+<p style="padding: 0px; box-sizing: border-box; letter-spacing: -1px; color: #333333; font-family: NanumSquareOTF_ac; font-size: medium;">■ 운영시간 : 09:00~18:00 (점심시간 : 12:00~13:00)</p>
+<p style="padding: 0px; box-sizing: border-box; letter-spacing: -1px; color: #333333; font-family: NanumSquareOTF_ac; font-size: medium;"><br /></p>
+<p style="padding: 0px; box-sizing: border-box; letter-spacing: -1px; color: #333333; font-family: NanumSquareOTF_ac; font-size: medium;"></p>
+<p style="padding: 0px; box-sizing: border-box; letter-spacing: -1px; color: #333333; font-family: NanumSquareOTF_ac; font-size: medium;"></p>
+</div>
+		<input type="hidden" name="optn1" id="optn1" value="2026-05-14">
+		<ul class="board_list">
+			<li class="next">
+			
+			
+			
+			<p class="title"><strong>다음글</strong>다음글이 없습니다.</p>
+			
+			
+			</li>
+			<li class="prev">
+			
+			
+				<p class="title"><strong>이전글</strong><a href="./view.do?optn1=2026-05-14&boardId=6538&menuNo=400008&pageIndex=&searchCondition=&searchKeyword=">[민간임대] 가좌역 스타타워 입주자 추가모집공고</a></p>
+				<p class="date">2026-05-14</p>
+			
+			
+			
+			</li>
+		</ul>
+		<div class="btnWrap3">
+          <a href="#" class="btn-purple btn-wide" onclick="goList();">목록</a>
+          
+        </div>
+	</div>
+</div>
+
+<script>
+	function goList(){
+		if(""==""){
+			location.href="/youth/bbs/BMSR00015/list.do?menuNo=400008&pageIndex=1&searchCondition=&searchKeyword=";
+		}else{
+			location.href="/youth/bbs/BMSR00015/list.do?menuNo=400008&pageIndex=&searchCondition=&searchKeyword=";
+		}
+		
+	}
+	
+	function previewAjax(file_url, file_name) {
+		
+		var apiKey = "RBKLXXZDMUBCHNHOEKZTMG";
+		var cc = "sg_094";
+		var fileUrl = encodeURIComponent(window.location.protocol+"//"+window.location.host+file_url);
+		var fileName = encodeURIComponent(file_name);
+		
+		
+		
+		window.open("https://seoul.viewstory.net/previewAjax.do?apikey={0}&cc={1}&url={2}&fileName={3}".format(apiKey, cc, fileUrl, fileName),"a", "width=1200, height=1000, left=100, top=50");
+		
+	}
+	
+	function preListen(file_url, file_name) {
+		var apiKey = "RBKLXXZDMUBCHNHOEKZTMG";
+		var cc = "sg_094";
+		var fileUrl = encodeURIComponent(window.location.protocol+"//"+window.location.host+file_url);
+		var fileName = encodeURIComponent(file_name);
+		window.open("https://seoul.viewstory.net/voiceOverAjax.do?apikey={0}&cc={1}&url={2}&fileName={3}".format(apiKey, cc, fileUrl, fileName), "a", "width=1200, height=1000, left=100, top=50");
+	}
+	
+	
+		
+		
+		String.prototype.format = function() {
+		var formatted = this;
+		for( var arg in arguments ) {
+		formatted = formatted.replace("{" +arg + "}", arguments[arg]);}
+		return formatted;
+		};
+		
+		$('.board_cont a[target="_blank"]').attr('title', '새창열림');/* 20260109*/
+
+</script>
+		
+    </div>
+		
+    <!-- FOOTER -->
+    </div><!-- #cont -->
+<footer class="footer inner">
+	<div class="foot-top">
+		<ul class="link">
+			<li><a href="/coHouse/main/main.do" target="_blank" title="새창 열림" class="quick_link">공동체주택플랫폼</a></li>
+			<li><a href="/soHouse/main/main.do" target="_blank" title="새창 열림" class="quick_link">사회주택플랫폼</a></li>
+			<li><a href="/youth/main/contents.do?menuNo=400036">개인정보처리방침</a></li>
+			<li><a>문의 1600-3456</a></li>
+			<!-- <li><a href="https://soco.seoul.go.kr/center/outline.do" target="_blank" title="새창 열림" class="quick_link">사회주택종합지원센터</a></li> -->
+		</ul>
+		<div class="sns">
+            <a href="https://www.facebook.com/2030.house" target="_blank" title="새창 열림">
+            	<img src="/resources/common/img/ico_facebook.png" alt="facebook">
+            </a>
+            <a href="https://www.instagram.com/seoul_youth_house" target="_blank" title="새창 열림">
+            	<img src="/resources/common/img/ico_instagram.png" alt="instagram">
+            </a>
+            <a href="https://blog.naver.com/seoul_youth_house" target="_blank" title="새창 열림">
+            	<img src="/resources/common/img/ico_blog.png" alt="blog">
+            </a>
+			<div class="familySite">
+				<button type="button" class="btn-fam">관련사이트</button>
+				<ul>
+					<li class="tit">유관기관</li>
+					<li><a href="https://www.i-sh.co.kr" target="_blank" title="새창열림">서울주택도시공사</a></li>
+					<li><a href="https://www.seoul.go.kr/main/index.jsp" target="_blank" title="새창열림">서울시 홈페이지</a></li>
+					<li class="tit">관련사이트</li>
+					<li><a href="https://housing.seoul.go.kr" target="_blank" title="새창열림">서울주거포털</a></li>
+					<li><a href="https://youth.seoul.go.kr/index.do" target="_blank" title="새창열림">청년몽땅정보통</a></li>
+					<li><a href="http://www.khug.or.kr" target="_blank" title="새창열림">주택도시보증공사</a></li>
+				</ul>
+	        	<!-- <select name="" id="familySite" title="Family site">
+					<option value="" class="tit">유관기관</option>
+					<option value="https://www.i-sh.co.kr" title="새창열림">&nbsp;&nbsp;&nbsp;&nbsp;서울주택도시공사</option>
+					<option value="https://news.seoul.go.kr/citybuild/archives/511188" title="새창열림">&nbsp;&nbsp;&nbsp;&nbsp;서울시 홈페이지</option>
+					<option value="" class="tit">관련사이트</option>
+					<option value="https://housing.seoul.go.kr" title="새창열림">&nbsp;&nbsp;&nbsp;&nbsp;서울시 주거포털</option>
+					<option value="https://youth.seoul.go.kr/site/main/home" title="새창열림">&nbsp;&nbsp;&nbsp;&nbsp;서울청년포털</option>
+					<option value="http://www.khug.or.kr" title="새창열림">&nbsp;&nbsp;&nbsp;&nbsp;HUG 주택도시보증공사</option>
+					<option value="https://www.seoul.go.kr" title="새창열림">&nbsp;&nbsp;&nbsp;&nbsp;SGI 서울보증</option>
+				</select>
+				<label for="familySite" class="hide">유관기관 및 관련사이트 바로가기</label> -->
+	        </div>
+		</div>
+	</div>
+	<div class="foot-bot">
+	    <div class="marks">
+	        <a href="https://soco.seoul.go.kr/" target="_blank" title="새창 열림" class="foot_logo">
+	        	<img src="/resources/common/img/logo_seoul.png" alt="서울특별시 로고">
+	        </a>
+	        <span class="wa"><img src="/resources/common/img/wa_mark.png" alt="과학기술정보통신부 WA(WEB접근성) 품질인증 마크, 웹와치(WebWatch) 2024.12.23 ~ 2025.12.22" /></span>
+	    </div>
+	    <div class="copy">
+	        <p>[04514] 서울특별시 중구 서소문로 124, 씨티스퀘어 13층 전략주택공급과</p>
+	        <p>[04375] 서울시 용산구 백범로99길 40, 용산베르디움프렌즈 102동 2층</p>
+	        <p>© Seoul Metropolitan Government All rights reserved.</p>
+	    </div>
+	    <div class="banner">
+	       	<script><!--//<![CDATA[
+			   var m3_b = '';
+			   var m3_u = (location.protocol=='https:'?'https://delivery.dighty.com/www/delivery/ajs.php':'http://delivery.dighty.com/www/delivery/ajs.php');
+			   var m3_r = Math.floor(Math.random()*99999999999);
+			   if(document.cookie.indexOf('ACEUACS=')>-1){ 
+			   var m3_b = document.cookie.substr(document.cookie.indexOf('ACEUACS=')+8,19);}
+			   if (!document.MAX_used) document.MAX_used = ',';
+			   document.write ("<scr"+"ipt type='text/javascript' src='"+m3_u);
+			   document.write ("?zoneid=940");
+			   document.write ('&amp;cb=' + m3_r);
+			   if (m3_b!='')document.write('&amp;bd=' + m3_b);
+			   if (document.MAX_used != ',') document.write ("&amp;exclude=" + document.MAX_used);
+			   document.write (document.charset ? '&amp;charset='+document.charset : (document.characterSet ? '&amp;charset='+document.characterSet : ''));
+			   document.write ("&amp;loc=" + escape(window.location));
+			   if (document.referrer) document.write ("&amp;referer=" + escape(document.referrer));
+			   if (document.context) document.write ("&context=" + escape(document.context));
+			   if (document.mmm_fo) document.write ("&amp;mmm_fo=1");
+			   document.write ("'><\/scr"+"ipt>");
+			//]]></script>
+			<noscript><a href='https://delivery.dighty.com/www/delivery/ck.php?n=8d6dc35e&amp;cb=INSERT_RANDOM_NUMBER_HERE' target='_blank' title="Dighty 광고 새창 열림">
+			<img src='https://delivery.dighty.com/www/delivery/avw.php?zoneid=940&amp;cb=INSERT_RANDOM_NUMBER_HERE&amp;n=8d6dc35e' alt=""></a></noscript>
+	    </div>
+	</div>
+</footer>
+<script>
+	// 관련사이트 바로가기
+	$(function(){
+	  // bind change event to select
+	  /* $('#familySite').on('change', function () {
+		  var url = $(this).val(); // get selected value
+		  if (url) { // require a URL
+			  window.open(url); // redirect
+		  }
+		  return false;
+	  }); */
+	  
+	  $('.familySite .btn-fam').click(function () {
+		    $(this).toggleClass("open");
+		    var target = $(this).next();
+		    target.slideToggle(150);
+		    return false;
+	})
+	$('.familySite >ul >li:last-child >a').focusout(function () {
+		$('.familySite >ul').slideUp();
+	});
+
+		$('.banner >a').attr('title', 'Dighty 광고 새창 열림')
+	});
+
+</script>
+<!-- ie css 변수적용 -->
+<script>
+    window.MSInputMethodContext && document.documentMode && document.write('<script src="https://cdn.jsdelivr.net/gh/nuxodin/ie11CustomProperties@4.1.0/ie11CustomProperties.min.js"><\/script>');
+</script>
+</section><!-- #wrap -->
+
+<script src="//weblog.eseoul.go.kr/wlo/js/install.js" ></script>
+	
+	<script>
+		window.onload = function() {
+		    Yjs.Gnb.init('G253', 'seoul-common-gnb');
+		};
+	</script>
+</body>
+</html>

--- a/src/lib/crawler/announcementService.test.ts
+++ b/src/lib/crawler/announcementService.test.ts
@@ -2,20 +2,18 @@
  * crawlNewAnnouncements 통합 테스트 (MSW 기반)
  *
  * 책임 범위:
- * - 합성 레이어가 fetchJsonText + retry + rateLimit + parseListJson을
- *   의도대로 엮어내는지 확인.
- * - 정상 흐름, 빈 응답, retry 흡수, retry 한도, limiter 공유.
+ * - 합성 레이어가 fetchJsonText + fetchHtml + retry + rateLimit
+ *   + parseListJson + parseDetailPage + isViewErrorPage를 의도대로 엮어내는지 확인.
+ * - JSON 정상 흐름, retry 흡수/한도, limiter 공유.
+ * - view.do 보강 fetch: gap 계산, 정상/633B 분기, 호출 회피.
  *
  * 책임이 아닌 것:
- * - parseListJson 정확성 (개별 단위 테스트가 담당).
- * - fetchJsonText / retry / rateLimit 단위 동작 (각 단위 테스트가 담당).
- *
- * 왜 MSW인가:
- * - service의 기본 fetcher는 fetchJsonText(=실재 fetch). MSW로 네트워크
- *   경계를 가로채면 헤더 검증/에러 매핑까지 통째로 함께 검증한다.
+ * - 각 파서·페처·정책 단위 정확성 (개별 단위 테스트가 담당).
  */
 
 import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
+import { readFileSync } from 'fs';
+import { join } from 'path';
 import { http, HttpResponse } from 'msw';
 import { setupServer } from 'msw/node';
 
@@ -23,9 +21,22 @@ import { crawlNewAnnouncements } from './announcementService';
 import { createRateLimiter } from './rateLimit';
 
 const LIST_URL = 'https://test.example.com/bbsListJson.json';
+const VIEW_BASE = 'https://test.example.com/view.do';
+const buildViewUrl = (boardId: number) => `${VIEW_BASE}?boardId=${boardId}`;
+
+// 실 사이트 fixture를 view.do 정상/에러 응답에 그대로 사용.
+const detailHtmlFixture = readFileSync(
+  join(__dirname, '__fixtures__', 'detailPage.html'),
+  'utf-8',
+);
+const viewErrorFixture = readFileSync(
+  join(__dirname, '__fixtures__', 'viewErrorPage.html'),
+  'utf-8',
+);
 
 const FAST = {
   listUrl: LIST_URL,
+  buildViewUrl,
   intervalMs: 0,
   retryOptions: {
     sleep: () => Promise.resolve(),
@@ -33,7 +44,6 @@ const FAST = {
   },
 };
 
-/** 가짜 JSON 응답 빌더 - parseListJson이 허용하는 최소 필드만 갖춘다. */
 function buildListJsonText(boardIds: number[]): string {
   return JSON.stringify({
     pagingInfo: { totRow: boardIds.length },
@@ -59,6 +69,24 @@ function jsonResponse(text: string, init: ResponseInit = {}) {
   });
 }
 
+function htmlResponse(body: string) {
+  return new HttpResponse(body, {
+    status: 200,
+    headers: { 'Content-Type': 'text/html; charset=utf-8' },
+  });
+}
+
+/** view.do MSW 핸들러: errorIds에 든 boardId만 633B 에러 페이지로 응답. */
+function viewHandler(errorIds: number[] = []) {
+  const errorSet = new Set(errorIds);
+  return http.get(VIEW_BASE, ({ request }) => {
+    const boardId = Number(new URL(request.url).searchParams.get('boardId'));
+    return htmlResponse(
+      errorSet.has(boardId) ? viewErrorFixture : detailHtmlFixture,
+    );
+  });
+}
+
 const server = setupServer();
 
 beforeAll(() => server.listen({ onUnhandledRequest: 'error' }));
@@ -73,13 +101,19 @@ describe('crawlNewAnnouncements', () => {
 
     expect(result.newAnnouncements).toEqual([]);
     expect(result.latestBoardId).toBe(100);
+    expect(result.skippedBoardIds).toEqual([]);
   });
 
-  it('모든 boardId가 lastBoardId 초과면 전부 새 공고로 반환', async () => {
+  it('모든 boardId가 lastBoardId 초과 + gap 없음이면 JSON만 반환, view.do 호출 0회', async () => {
+    let viewCalls = 0;
     server.use(
       http.post(LIST_URL, () =>
         jsonResponse(buildListJsonText([103, 102, 101])),
       ),
+      http.get(VIEW_BASE, () => {
+        viewCalls += 1;
+        return htmlResponse(detailHtmlFixture);
+      }),
     );
 
     const result = await crawlNewAnnouncements({ ...FAST, lastBoardId: 100 });
@@ -88,22 +122,27 @@ describe('crawlNewAnnouncements', () => {
       103, 102, 101,
     ]);
     expect(result.latestBoardId).toBe(103);
+    expect(result.skippedBoardIds).toEqual([]);
+    expect(viewCalls).toBe(0);
   });
 
-  it('일부만 lastBoardId 초과면 초과분만 새 공고로 반환', async () => {
+  it('일부만 lastBoardId 초과면 초과분만 반환 (gap의 비존재 boardId는 skip)', async () => {
+    // JSON max=103, lastBoardId=100, JSON에 없는 101은 633B로 응답 → skip.
     server.use(
       http.post(LIST_URL, () =>
         jsonResponse(buildListJsonText([103, 102, 99, 98])),
       ),
+      viewHandler([101]),
     );
 
     const result = await crawlNewAnnouncements({ ...FAST, lastBoardId: 100 });
 
     expect(result.newAnnouncements.map((a) => a.boardId)).toEqual([103, 102]);
     expect(result.latestBoardId).toBe(103);
+    expect(result.skippedBoardIds).toEqual([101]);
   });
 
-  it('5xx 1회 후 200이면 retry로 흡수해 정상 결과를 낸다', async () => {
+  it('5xx 1회 후 200이면 retry로 흡수', async () => {
     let calls = 0;
     server.use(
       http.post(LIST_URL, () => {
@@ -120,7 +159,7 @@ describe('crawlNewAnnouncements', () => {
     expect(result.newAnnouncements[0].boardId).toBe(100);
   });
 
-  it('retry 한도 내내 5xx면 호출자에게 에러를 전파한다', async () => {
+  it('retry 한도 내내 5xx면 호출자에게 에러 전파', async () => {
     let calls = 0;
     server.use(
       http.post(LIST_URL, () => {
@@ -132,7 +171,7 @@ describe('crawlNewAnnouncements', () => {
     await expect(
       crawlNewAnnouncements({ ...FAST, lastBoardId: 99 }),
     ).rejects.toThrow();
-    expect(calls).toBe(3); // retry 기본 maxAttempts=3
+    expect(calls).toBe(3);
   });
 
   it('두 service 호출이 limiter를 공유하면 호출 간 간격이 직렬화된다', async () => {
@@ -163,8 +202,69 @@ describe('crawlNewAnnouncements', () => {
       rateLimiter: limiter,
     });
 
-    // 사이클당 1회 호출. 두 사이클이면 두 번째 호출만 1000ms 대기.
     const realSleeps = sleepMsLog.filter((ms) => ms > 0);
     expect(realSleeps).toEqual([1000]);
+  });
+
+  it('gap이 있고 모두 정상 view.do면 JSON + view.do 보강을 합쳐 반환', async () => {
+    // JSON에는 [103, 100]만 들어와 lastBoardId=99 기준 gap = [101, 102].
+    server.use(
+      http.post(LIST_URL, () => jsonResponse(buildListJsonText([103, 100]))),
+      viewHandler(),
+    );
+
+    const result = await crawlNewAnnouncements({ ...FAST, lastBoardId: 99 });
+
+    // 앞 2개는 JSON 항목, 뒤 2개는 view.do 보강.
+    expect(result.newAnnouncements.map((a) => a.boardId)).toEqual([
+      103, 100, 101, 102,
+    ]);
+    expect(result.latestBoardId).toBe(103);
+    expect(result.skippedBoardIds).toEqual([]);
+  });
+
+  it('gap 중 일부가 633B 에러 페이지면 skippedBoardIds로 분리', async () => {
+    // gap = [101, 102]. 101은 빈 번호(633B), 102는 정상.
+    server.use(
+      http.post(LIST_URL, () => jsonResponse(buildListJsonText([103, 100]))),
+      viewHandler([101]),
+    );
+
+    const result = await crawlNewAnnouncements({ ...FAST, lastBoardId: 99 });
+
+    expect(result.newAnnouncements.map((a) => a.boardId)).toEqual([
+      103, 100, 102,
+    ]);
+    expect(result.skippedBoardIds).toEqual([101]);
+  });
+
+  it('gap 전체가 633B면 newFromView는 비고 skippedBoardIds에 전부', async () => {
+    server.use(
+      http.post(LIST_URL, () => jsonResponse(buildListJsonText([103, 100]))),
+      viewHandler([101, 102]),
+    );
+
+    const result = await crawlNewAnnouncements({ ...FAST, lastBoardId: 99 });
+
+    expect(result.newAnnouncements.map((a) => a.boardId)).toEqual([103, 100]);
+    expect(result.skippedBoardIds).toEqual([101, 102]);
+  });
+
+  it('view.do 보강 항목은 agency=null이고 attachmentId는 fileDown URL에서 추출', async () => {
+    server.use(
+      http.post(LIST_URL, () => jsonResponse(buildListJsonText([103]))),
+      viewHandler(),
+    );
+
+    // lastBoardId=100 → gap = [101, 102] → 둘 다 view.do로 채워짐.
+    const result = await crawlNewAnnouncements({ ...FAST, lastBoardId: 100 });
+
+    const fromView = result.newAnnouncements.filter((a) => a.boardId !== 103);
+    expect(fromView.length).toBeGreaterThan(0);
+    for (const item of fromView) {
+      expect(item.agency).toBeNull();
+      // detailPage fixture에 fileDown.do 첨부가 있으므로 atchFileId 추출 가능.
+      expect(item.attachmentId).toBeTruthy();
+    }
   });
 });

--- a/src/lib/crawler/announcementService.ts
+++ b/src/lib/crawler/announcementService.ts
@@ -3,31 +3,36 @@
  *
  * 책임 범위:
  * - JSON 목록 API(bbsListJson.json) 1회 호출로 boardId·본문·메타데이터 일괄 수신.
+ * - JSON에 빠진 gap(=lastBoardId+1 ~ JSON 최신 boardId 사이의 미관측 ID)을
+ *   view.do로 직접 보강 fetch. 633B 에러 페이지는 skippedBoardIds로 분리.
  * - 각 호출에 rateLimit과 retry를 일관되게 적용.
- * - lastBoardId 초과분만 새 공고로 반환.
  *
  * 책임이 아닌 것:
- * - HTTP 자체 (fetchJsonText).
+ * - HTTP 자체 (fetchJsonText / fetchHtml).
  * - 재시도 정책 (retry).
  * - 호출 간 간격 (rateLimit).
- * - JSON 파싱 (parseListJson).
- * - view.do 보강 fetch (PR D 이후에 별도 도입 예정).
+ * - JSON / HTML 파싱 (parseListJson, parseDetailPage).
+ * - 비존재 boardId 판별 (isViewErrorPage).
  * - DB 저장이나 lastBoardId persistence (호출자의 일).
  *
- * 데이터 소스 결정 근거: docs/adr/002-crawling-data-source.md
+ * 데이터 소스 결정 근거: docs/adr/002-crawling-data-source.md (옵션 C 하이브리드)
  */
 
+import { fetchHtml, type FetchHtmlOptions } from './fetchHtml';
 import { fetchJsonText, type FetchJsonOptions } from './fetchJsonText';
 import { withRetry, type RetryOptions } from './retry';
 import { createRateLimiter, type RateLimiter } from './rateLimit';
 import { parseListJson } from './parseListJson';
-import type { AnnouncementListItem } from '@/types/announcement';
+import { parseDetailPage } from './parseDetailPage';
+import { isViewErrorPage } from './isViewErrorPage';
+import type {
+  AnnouncementDetail,
+  AnnouncementListItem,
+} from '@/types/announcement';
 
-/** 청년안심주택 모집공고 목록 JSON API. */
 const DEFAULT_LIST_URL =
   'https://soco.seoul.go.kr/youth/pgm/home/yohome/bbsListJson.json';
 
-/** JSON API에 보내는 form body 기본값. bbsId=BMSR00015가 모집공고 게시판. */
 const DEFAULT_LIST_BODY: Record<string, string> = {
   bbsId: 'BMSR00015',
   pageIndex: '1',
@@ -38,11 +43,12 @@ const DEFAULT_LIST_BODY: Record<string, string> = {
   optn5: '',
 };
 
-/** Referer가 없으면 사이트가 거부할 수 있어 동일 출처 list.do를 명시. */
 const DEFAULT_REFERER =
   'https://soco.seoul.go.kr/youth/bbs/BMSR00015/list.do?menuNo=400008';
 
-/** 호출 간 기본 간격 - 서버 부담 최소화 + 차단 회피. */
+const DEFAULT_VIEW_URL_BUILDER = (boardId: number): string =>
+  `https://soco.seoul.go.kr/youth/bbs/BMSR00015/view.do?boardId=${boardId}&menuNo=400008`;
+
 const DEFAULT_INTERVAL_MS = 1_000;
 
 export interface CrawlAnnouncementsOptions {
@@ -54,32 +60,37 @@ export interface CrawlAnnouncementsOptions {
   listUrl?: string;
   /** form body override. */
   listBody?: Record<string, string>;
-  /** 외부 주입용 fetcher - 테스트에서 MSW 또는 fake로 교체. */
+  /** JSON API fetcher - 테스트에서 MSW로 교체. */
   fetcher?: (url: string, options?: FetchJsonOptions) => Promise<string>;
+  /** boardId -> view.do URL 빌더 (테스트 override). */
+  buildViewUrl?: (boardId: number) => string;
+  /** view.do HTML fetcher - 테스트에서 MSW로 교체. */
+  viewFetcher?: (url: string, options?: FetchHtmlOptions) => Promise<string>;
   /** 재시도 옵션 - 미지정 시 retry 모듈 기본값. */
   retryOptions?: RetryOptions;
-  /** 외부 주입할 RateLimiter (여러 service 호출이 같은 limiter를 공유하려면). */
+  /** 외부 주입할 RateLimiter (공유 limiter 패턴). */
   rateLimiter?: RateLimiter;
 }
 
 export interface CrawlAnnouncementsResult {
-  /** 이번 회차에 새로 발견한 공고 목록 (boardId > lastBoardId). */
+  /**
+   * 이번 회차에 새로 발견한 공고 목록.
+   * - JSON 응답의 lastBoardId 초과분 + view.do 보강분.
+   * - JSON 항목이 앞, view.do 항목이 뒤.
+   */
   newAnnouncements: AnnouncementListItem[];
   /**
    * 응답에서 관측한 가장 큰 boardId.
-   * 다음 회차의 lastBoardId로 사용한다.
    * resultList가 비어 있으면 입력 lastBoardId를 그대로 반환.
    */
   latestBoardId: number;
+  /**
+   * gap 후보 중 view.do가 633B 에러 페이지로 응답한 boardId.
+   * 운영 관찰용 (빈 번호가 얼마나 끼는지 추적).
+   */
+  skippedBoardIds: number[];
 }
 
-/**
- * 새 공고를 한 회차 분 크롤링한다.
- *
- * 합성 순서: rateLimit OUTSIDE retry.
- *  - acquire()로 호출 슬롯을 잡은 뒤 withRetry가 안에서 시도/대기/재시도.
- *  - 재시도 백오프와 호출 간격이 서로 간섭하지 않는다.
- */
 export async function crawlNewAnnouncements(
   options: CrawlAnnouncementsOptions,
 ): Promise<CrawlAnnouncementsResult> {
@@ -89,11 +100,13 @@ export async function crawlNewAnnouncements(
     listUrl = DEFAULT_LIST_URL,
     listBody = DEFAULT_LIST_BODY,
     fetcher = fetchJsonText,
+    buildViewUrl = DEFAULT_VIEW_URL_BUILDER,
+    viewFetcher = fetchHtml,
     retryOptions,
     rateLimiter = createRateLimiter({ intervalMs }),
   } = options;
 
-  const fetchWithPolicy = (url: string) =>
+  const fetchJsonWithPolicy = (url: string) =>
     rateLimiter.acquire().then(() =>
       withRetry(
         () =>
@@ -105,18 +118,92 @@ export async function crawlNewAnnouncements(
       ),
     );
 
-  const jsonText = await fetchWithPolicy(listUrl);
+  const fetchViewWithPolicy = (url: string) =>
+    rateLimiter
+      .acquire()
+      .then(() =>
+        withRetry(
+          () => viewFetcher(url, { headers: { Referer: DEFAULT_REFERER } }),
+          retryOptions,
+        ),
+      );
+
+  // 1) JSON API 1회 호출.
+  const jsonText = await fetchJsonWithPolicy(listUrl);
   const items = parseListJson(jsonText);
 
   if (items.length === 0) {
-    return { newAnnouncements: [], latestBoardId: lastBoardId };
+    return {
+      newAnnouncements: [],
+      latestBoardId: lastBoardId,
+      skippedBoardIds: [],
+    };
   }
 
+  const observedIds = new Set(items.map((i) => i.boardId));
   const latestBoardId = items.reduce(
     (max, item) => (item.boardId > max ? item.boardId : max),
     -Infinity,
   );
-  const newAnnouncements = items.filter((item) => item.boardId > lastBoardId);
 
-  return { newAnnouncements, latestBoardId };
+  // 2) JSON 응답의 lastBoardId 초과분 = 즉시 신규 공고로 채택.
+  const newFromJson = items.filter((item) => item.boardId > lastBoardId);
+
+  // 3) gap = lastBoardId+1 ~ latestBoardId 범위에서 JSON에 안 들어온 것들.
+  const gap: number[] = [];
+  for (let id = lastBoardId + 1; id <= latestBoardId; id++) {
+    if (!observedIds.has(id)) gap.push(id);
+  }
+
+  // 4) gap의 각 boardId를 view.do로 직접 확인.
+  //    - 633B 에러 페이지 → 비존재 → skippedBoardIds.
+  //    - 정상 → parseDetailPage → AnnouncementListItem으로 변환 후 newFromView.
+  const newFromView: AnnouncementListItem[] = [];
+  const skippedBoardIds: number[] = [];
+
+  for (const boardId of gap) {
+    const html = await fetchViewWithPolicy(buildViewUrl(boardId));
+    if (isViewErrorPage(html)) {
+      skippedBoardIds.push(boardId);
+      continue;
+    }
+    const detail = parseDetailPage(html, boardId);
+    newFromView.push(detailToListItem(detail));
+  }
+
+  return {
+    newAnnouncements: [...newFromJson, ...newFromView],
+    latestBoardId,
+    skippedBoardIds,
+  };
+}
+
+/**
+ * AnnouncementDetail(parseDetailPage 결과)을 AnnouncementListItem 형태로 변환.
+ *
+ * 매핑 손실:
+ * - agency: JSON에는 있고 HTML에는 명시적 필드가 없어 null로 둔다.
+ * - attachmentId: attachmentUrl(`fileDown.do?atchFileId=...`)에서 추출.
+ *
+ * JSON 항목과 view.do 보강 항목을 같은 결과 배열에 담기 위한 어댑터.
+ */
+function detailToListItem(detail: AnnouncementDetail): AnnouncementListItem {
+  return {
+    boardId: detail.boardId,
+    title: detail.title,
+    announcementType: detail.announcementType,
+    recruitmentType: detail.recruitmentType,
+    agency: null,
+    postDate: detail.postDate,
+    applicationStartDate: detail.applicationStartDate,
+    applicationEndDate: detail.applicationEndDate,
+    attachmentId: extractAttachmentId(detail.attachmentUrl),
+    rawContent: detail.rawContent,
+  };
+}
+
+function extractAttachmentId(url: string | null): string | null {
+  if (!url) return null;
+  const match = url.match(/[?&]atchFileId=([^&]+)/);
+  return match ? match[1] : null;
 }

--- a/src/lib/crawler/fetchHtml.ts
+++ b/src/lib/crawler/fetchHtml.ts
@@ -22,6 +22,8 @@ export interface FetchHtmlOptions {
   userAgent?: string;
   /**타임아웃 (ms, 기본 10초) */
   timeoutMs?: number;
+  /** 추가 헤더 (Referer 등). User-Agent/Accept과 머지된다. */
+  headers?: Record<string, string>;
   /** 외부 주입용 fetch - 테스트에서 MSW 대신 직접 mock 가능 */
   fetchImpl?: typeof fetch;
 }
@@ -64,6 +66,7 @@ export async function fetchHtml(
   const {
     userAgent = DEFAULT_USER_AGENT,
     timeoutMs = DEFAULT_TIMEOUT_MS,
+    headers,
     fetchImpl = fetch,
   } = options;
 
@@ -76,6 +79,7 @@ export async function fetchHtml(
       headers: {
         'User-Agent': userAgent,
         Accept: 'text/html,application/xhtml+xml',
+        ...headers,
       },
       signal: controller.signal,
     });

--- a/src/lib/crawler/parseDetailPage.test.ts
+++ b/src/lib/crawler/parseDetailPage.test.ts
@@ -8,78 +8,81 @@ const fixtureHtml = readFileSync(
   'utf-8',
 );
 
+// 실 사이트(soco.seoul.go.kr) 2026-05-20 응답 기반 — boardId 6539번 공고.
+const BOARD_ID = 6539;
+
 describe('parseDetailPage', () => {
   it('공고 제목을 추출한다', () => {
-    const result = parseDetailPage(fixtureHtml, 6479);
+    const result = parseDetailPage(fixtureHtml, BOARD_ID);
 
-    expect(result.title).toBe('[민간임대] 태릉입구역 이니티움 추가모집공고');
+    expect(result.title).toBe('[민간임대] 태릉입구역 와이엔타워 추가모집공고');
   });
 
   it('boardId를 그대로 반환한다', () => {
-    const result = parseDetailPage(fixtureHtml, 6479);
+    const result = parseDetailPage(fixtureHtml, BOARD_ID);
 
-    expect(result.boardId).toBe(6479);
+    expect(result.boardId).toBe(BOARD_ID);
   });
 
   it('공고 유형을 판별한다 - 민간임대', () => {
-    const result = parseDetailPage(fixtureHtml, 6479);
+    const result = parseDetailPage(fixtureHtml, BOARD_ID);
 
     expect(result.announcementType).toBe('private');
   });
 
   it('모집 구분을 판별한다 - 추가모집', () => {
-    const result = parseDetailPage(fixtureHtml, 6479);
+    const result = parseDetailPage(fixtureHtml, BOARD_ID);
 
     expect(result.recruitmentType).toBe('additional');
   });
 
   it('공고게시일을 추출한다', () => {
-    const result = parseDetailPage(fixtureHtml, 6479);
+    const result = parseDetailPage(fixtureHtml, BOARD_ID);
 
-    expect(result.postDate).toBe('2026-03-26');
+    expect(result.postDate).toBe('2026-05-14');
   });
 
   it('청약신청일을 추출한다', () => {
-    const result = parseDetailPage(fixtureHtml, 6479);
+    const result = parseDetailPage(fixtureHtml, BOARD_ID);
 
-    expect(result.applicationStartDate).toBe('2026-03-30');
+    expect(result.applicationStartDate).toBe('2026-05-18');
   });
 
   it('지역구를 추출한다', () => {
-    const result = parseDetailPage(fixtureHtml, 6479);
+    const result = parseDetailPage(fixtureHtml, BOARD_ID);
 
     expect(result.district).toBe('노원구');
   });
 
   it('단지명을 추출한다', () => {
-    const result = parseDetailPage(fixtureHtml, 6479);
+    const result = parseDetailPage(fixtureHtml, BOARD_ID);
 
-    expect(result.complexName).toBe('태릉입구역 이니티움');
+    expect(result.complexName).toBe('와이엔타워');
   });
 
   it('주소를 추출한다', () => {
-    const result = parseDetailPage(fixtureHtml, 6479);
+    const result = parseDetailPage(fixtureHtml, BOARD_ID);
 
-    expect(result.address).toContain('노원구 공릉동');
+    expect(result.address).toContain('노원구');
   });
 
   it('공급호수를 추출한다', () => {
-    const result = parseDetailPage(fixtureHtml, 6479);
+    const result = parseDetailPage(fixtureHtml, BOARD_ID);
 
-    expect(result.totalUnits).toBe(100);
+    expect(result.totalUnits).toBe(195);
   });
 
   it('첨부파일 URL을 추출한다', () => {
-    const result = parseDetailPage(fixtureHtml, 6479);
+    const result = parseDetailPage(fixtureHtml, BOARD_ID);
 
     expect(result.attachmentUrl).toContain('fileDown.do');
     expect(result.attachmentUrl).toContain('soco.seoul.go.kr');
   });
 
   it('첨부파일명을 추출한다', () => {
-    const result = parseDetailPage(fixtureHtml, 6479);
+    const result = parseDetailPage(fixtureHtml, BOARD_ID);
 
-    expect(result.attachmentName).toContain('추가모집공고문.pdf');
+    expect(result.attachmentName).toBeTruthy();
   });
 
   it('공공임대 제목에서 유형을 정확히 판별한다', () => {


### PR DESCRIPTION
## Summary

ADR 002 옵션 C 하이브리드의 **나머지 절반**(view.do 보강). JSON API가 페이지 단위로 응답하기 때문에 `lastBoardId+1 ~ JSON 최신 boardId` 사이의 미관측 ID(gap)가 생길 수 있고, 그 gap을 view.do로 직접 호출해 누락 없이 채운다. 비존재 boardId는 PR C에서 미리 만든 `isViewErrorPage`로 633B 에러 페이지 판별 후 `skippedBoardIds`로 분리.

본 PR로 epic #19 종료.

## 주요 변경 사항

### 1. `parseDetailPage` 실 사이트 검증 (코드는 무변경)

- fixture를 PR 초기 시드 HTML에서 **실 view.do 응답**(`boardId=6539`, 39199B)으로 교체
- selector(`p.subject`, `ul.view_data > li`, `div.board_cont`, `a[href*="fileDown.do"]`, 본문 `■단지명` 패턴)는 모두 실 응답에서 그대로 동작 — 코드 수정 0줄
- `parseDetailPage.test.ts` 기댓값을 6539번 공고에 맞게 갱신 (제목, 게시일, 단지명, 호수 등)

### 2. `announcementService` 본체 확장 — view.do 보강 fetch

- `observedIds` = JSON 응답의 boardId 집합
- `gap` = `[lastBoardId+1 .. latestBoardId]` 중 `observedIds`에 없는 ID
- 각 gap boardId에 GET view.do:
  - `isViewErrorPage(html)` → `skippedBoardIds.push(boardId)`
  - 정상 → `parseDetailPage` → `detailToListItem` 어댑터로 변환 → `newFromView`
- 최종 결과: `[...newFromJson, ...newFromView]` (JSON 항목이 앞, 보강이 뒤)
- `skippedBoardIds` 필드 재도입 (PR C에서 일시 제거됐던 것)

### 3. `detailToListItem` 어댑터 (service 내부 helper)

`parseDetailPage`는 `AnnouncementDetail`을 반환하지만 service의 결과는 `AnnouncementListItem[]`. 두 타입을 합치는 매핑:
- 직접 매핑: `boardId`, `title`, `announcementType`, `recruitmentType`, `postDate`, `applicationStartDate`, `applicationEndDate`, `rawContent`
- `agency`: HTML에 명시적 필드가 없어 `null`
- `attachmentId`: `attachmentUrl`의 `?atchFileId=...` 쿼리에서 정규식으로 추출

### 4. `fetchHtml`에 `headers` 옵션 추가

view.do 호출에도 `Referer` 헤더가 필요해, 기존 GET 함수에 `headers?: Record<string, string>` 옵션을 추가하고 내부에서 User-Agent/Accept와 머지.

### 5. 통합 테스트 보강 (4 시나리오 신규)

- gap 모두 정상 view.do → JSON + 보강 합산
- gap 일부 633B → 일부는 skip, 일부는 newFromView
- gap 전체 633B → newFromView 비고 skipped에 전부
- view.do 보강 항목의 `agency=null` + `attachmentId` 추출 검증

기존 6 시나리오에 `skippedBoardIds` 검증도 추가.

## 참고 사항

### 검증

- `pnpm test`: 58/58 통과 (이전 54 + parseDetailPage 갱신 0건 추가 + service 4건 추가)
- `pnpm typecheck`: 통과
- `pnpm lint`: clean

### 데이터 흐름 (epic #19 완성 후)

```
POST bbsListJson.json
   ↓
parseListJson → AnnouncementListItem[] (JSON에서 받은 보드들)
   ↓
[ lastBoardId+1 .. maxBoardId ] - observedIds = gap
   ↓
for each gap boardId:
   GET view.do
   ↓
   isViewErrorPage?
     yes → skippedBoardIds
     no  → parseDetailPage → detailToListItem
   ↓
newAnnouncements = [JSON 항목들, view.do 보강 항목들]
```

### 관련 이슈

- Epic: #19 — 본 PR 머지 후 close
- 후속 (Sprint 1 잔여): #12 (DB 저장), #13 (스케줄러)