### PR TITLE
chore: epic #19 머지 후 CLAUDE.md/HANDOFF.md 현재 스냅샷 동기화

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,16 +11,17 @@ GitHub: `ofekim0/cheong-an` (Public, MIT)
 - 기존에 청년안심주택 전용 알림 서비스가 없어서 직접 만드는 프로젝트
 - 상세: `docs/PROJECT_PLAN.md`
 
-### 현재 진행 상황 (2026-05-19 기준)
+### 현재 진행 상황 (2026-05-22 기준)
 
 - **Phase 0 (프로젝트 셋업)**: 완료 — Next.js, ESLint, Vitest, CI/CD 구축
 - **Phase 1 Sprint 1 (크롤링 파이프라인)**: 진행 중
   - 완료:
-    - 파서 레이어 (`parseMainPage`, `parseDetailPage`, `checkBoardId` + 단위 테스트)
+    - 파서 레이어 (`parseDetailPage`, `parseListJson` + 단위 테스트). 메인 페이지 HTML 파서 (`parseMainPage`, `checkBoardId`)는 epic #19에서 폐기됨
     - `announcements` 테이블 마이그레이션 (`supabase/migrations/00001_create_announcements.sql`), 타입 정의 (`src/types/announcement.ts`)
-    - 서비스 레이어 (`fetchHtml`, `retry`, `rateLimit`, `announcementService` + MSW 통합 테스트)
-    - 학습 정리 문서는 `docs/learning/` 하위 (`step4-crawling.md`, `step5-fetch-html.md`, `step5-retry.md`, `step5-rate-limit.md`, `step5-service-layer.md`, `step5-msw-testing.md`)
-  - 잔여: ① 상세 페이지 검증 로직(`needsVerification` 실제 fetch) ② Supabase 연동(저장 + `lastBoardId` 추적) ③ 스케줄러(Vercel Cron / GitHub Actions, 1시간 간격)
+    - 서비스 레이어 (`fetchHtml`, `fetchJsonText`, `retry`, `rateLimit`, `isViewErrorPage`, `announcementService` + MSW 통합 테스트)
+    - 데이터 소스 재설계 (epic #19, PR #20~23 머지): JSON API(주) + view.do(gap 보강) 하이브리드. 결정 근거는 `docs/adr/002-crawling-data-source.md`
+    - 학습 정리 문서는 `docs/learning/` 하위 (`step4-crawling.md`, `step5-fetch-html.md`, `step5-retry.md`, `step5-rate-limit.md`, `step5-service-layer.md`, `step5-msw-testing.md`, `step6-data-source-redesign.md`)
+  - 잔여: ① Supabase 연동(저장 + `lastBoardId` 추적, 이슈 #12) ② 스케줄러(Vercel Cron / GitHub Actions, 1시간 간격, 이슈 #13)
   - 상세 진척과 인계 컨텍스트는 `HANDOFF.md` § 0 참고
 - **Phase 1 Sprint 2 (알림 시스템 + 기본 UI)**: 미착수
 

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -5,30 +5,31 @@
 
 ---
 
-## 0. 최신 상태 (2026-05-19 기준)
+## 0. 최신 상태 (2026-05-22 기준)
 
 ### 완료된 Step
 
-| Step     | 내용                                                                  | 산출물                                                                                                                                                                                                     |
-| -------- | --------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Step 2   | Next.js 초기화, Prettier/husky/lint-staged, Vitest/Playwright         | `docs/learning/step2-essentials.md`, `docs/learning/step2-project-init.md`                                                                                                                                 |
-| Step 3   | Vercel 연동, GitHub Actions CI (lint + 타입 체크 + 테스트)            | `docs/learning/step3-ci-setup.md`                                                                                                                                                                          |
-| Step 4   | 크롤링 파서 레이어 + DB 스키마 + 타입 (`feat/crawling-pipeline` 머지) | `src/lib/crawler/parseMainPage.ts`, `parseDetailPage.ts`, `checkBoardId.ts` + 테스트, `supabase/migrations/00001_create_announcements.sql`, `src/types/announcement.ts`, `docs/learning/step4-crawling.md` |
-| Step 5-a | HTTP fetch + 재시도 유틸리티                                          | `src/lib/crawler/fetchHtml.ts`, `retry.ts`, `docs/learning/step5-fetch-html.md`, `docs/learning/step5-retry.md`                                                                                            |
-| Step 5-b | rateLimit (요청 간격 제어, 단일 프로세스 큐)                          | `src/lib/crawler/rateLimit.ts`, `docs/learning/step5-rate-limit.md`                                                                                                                                        |
-| Step 5-c | announcementService 합성 레이어 (fetch+retry+rateLimit+파서 조합)     | `src/lib/crawler/announcementService.ts`, `docs/learning/step5-service-layer.md`                                                                                                                           |
-| Step 5-d | MSW 기반 announcementService 통합 테스트 (6개 시나리오)               | `src/lib/crawler/announcementService.test.ts`, `docs/learning/step5-msw-testing.md`                                                                                                                        |
-| ADR 001  | 기술 스택 선정 근거 문서화                                            | `docs/adr/001-tech-stack.md`                                                                                                                                                                               |
+| Step     | 내용                                                                                            | 산출물                                                                                                                                                                                                                                                                                                                   |
+| -------- | ----------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Step 2   | Next.js 초기화, Prettier/husky/lint-staged, Vitest/Playwright                                   | `docs/learning/step2-essentials.md`, `docs/learning/step2-project-init.md`                                                                                                                                                                                                                                               |
+| Step 3   | Vercel 연동, GitHub Actions CI (lint + 타입 체크 + 테스트)                                      | `docs/learning/step3-ci-setup.md`                                                                                                                                                                                                                                                                                        |
+| Step 4   | 크롤링 파서 레이어 + DB 스키마 + 타입 (`feat/crawling-pipeline` 머지)                           | `src/lib/crawler/parseDetailPage.ts` + 테스트, `supabase/migrations/00001_create_announcements.sql`, `src/types/announcement.ts`, `docs/learning/step4-crawling.md` (※ `parseMainPage.ts`, `checkBoardId.ts`는 Step 6에서 폐기)                                                                                          |
+| Step 5-a | HTTP fetch + 재시도 유틸리티                                                                    | `src/lib/crawler/fetchHtml.ts`, `retry.ts`, `docs/learning/step5-fetch-html.md`, `docs/learning/step5-retry.md`                                                                                                                                                                                                          |
+| Step 5-b | rateLimit (요청 간격 제어, 단일 프로세스 큐)                                                    | `src/lib/crawler/rateLimit.ts`, `docs/learning/step5-rate-limit.md`                                                                                                                                                                                                                                                      |
+| Step 5-c | announcementService 합성 레이어 (fetch+retry+rateLimit+파서 조합)                               | `src/lib/crawler/announcementService.ts`, `docs/learning/step5-service-layer.md`                                                                                                                                                                                                                                         |
+| Step 5-d | MSW 기반 announcementService 통합 테스트                                                        | `src/lib/crawler/announcementService.test.ts`, `docs/learning/step5-msw-testing.md`                                                                                                                                                                                                                                      |
+| Step 6   | 데이터 소스 재설계: JSON API(주) + view.do(gap 보강) 하이브리드 (epic #19, PR #20~23, #25 머지) | `src/lib/crawler/parseListJson.ts`, `fetchJsonText.ts`, `isViewErrorPage.ts`, `announcementService.ts` 재작성, `__fixtures__/{listJson.json,viewErrorPage.html,detailPage.html}` 실 응답 박제, `docs/learning/step6-data-source-redesign.md`. 기존 `parseMainPage.ts`/`checkBoardId.ts` 폐기. 단위·통합 테스트 58개 그린 |
+| ADR 001  | 기술 스택 선정 근거 문서화                                                                      | `docs/adr/001-tech-stack.md`                                                                                                                                                                                                                                                                                             |
+| ADR 002  | 크롤링 데이터 소스 전략 — 옵션 비교 + C(하이브리드) 채택                                        | `docs/adr/002-crawling-data-source.md`                                                                                                                                                                                                                                                                                   |
 
-### 진행 중: Sprint 1 잔여 (`feat/crawler-service-layer`)
+### 진행 중: Sprint 1 잔여
 
-서비스 레이어 + 통합 테스트까지 마무리됨. 다음 단계는 아래.
+크롤링 파이프라인 본체(데이터 소스 재설계 포함)는 마무리됨. 다음은 저장과 트리거.
 
 ### 다음 할 일 (Sprint 1 잔여)
 
-1. **상세 페이지 검증 로직**: `needsVerification` ID를 실제 fetch하여 존재 여부 확인
-2. **Supabase 연동**: 파싱 결과 저장 + `lastBoardId` 추적
-3. **스케줄러**: Vercel Cron 또는 GitHub Actions로 주기 실행 (1시간 간격)
+1. **Supabase 연동** (이슈 #12): 파싱 결과 저장 + `lastBoardId` 추적
+2. **스케줄러** (이슈 #13): Vercel Cron 또는 GitHub Actions로 주기 실행 (1시간 간격)
 
 ### 용어 매핑
 


### PR DESCRIPTION
## Summary

epic #19 (PR #20~23, #25)가 모두 머지되면서 데이터 소스 재설계가 완료됐지만, 프로젝트의 "현재 스냅샷" 역할을 하는 두 문서(`CLAUDE.md`의 "현재 진행 상황" 섹션, `HANDOFF.md` § 0)가 옛 상태에 머물러 있던 것을 동기화합니다.

코드 변경 없음 — 문서만 사실 일치시키는 chore PR.

## 주요 변경 사항

### 1. CLAUDE.md "현재 진행 상황" 섹션 갱신

- 헤더 날짜: `2026-05-19` → `2026-05-22`
- 완료 항목에 추가:
  - epic #19 데이터 소스 재설계 (PR #20~23) + ADR 002 참조
  - `fetchJsonText`, `isViewErrorPage` 등 신규 모듈
  - 학습 문서 `step6-data-source-redesign.md`
- 파서 레이어 설명에서 폐기된 `parseMainPage`, `checkBoardId` 제거 (Step 6 폐기 명시)
- Sprint 1 잔여: `①` 상세 페이지 검증 로직 제거 (epic #19로 완료) → `①` Supabase #12, `②` 스케줄러 #13만 남음

### 2. HANDOFF.md § 0 갱신

- 헤더 날짜: `2026-05-19` → `2026-05-22`
- 완료 Step 테이블에 추가:
  - **Step 6**: 데이터 소스 재설계 (JSON API + view.do gap 보강)
  - **ADR 002**: 크롤링 데이터 소스 전략
- Step 4 산출물에서 폐기된 `parseMainPage.ts`, `checkBoardId.ts` 제거 + Step 6에서 폐기됐다는 주석 추가
- Step 5-d "6개 시나리오" 표기 제거 (현재 10개로 확장됨, 시나리오 수가 자주 바뀌므로 표기 자체를 제거)
- "진행 중" 설명과 "다음 할 일"에서 상세 페이지 검증 항목 제거

## 참고 사항

- 관련 epic: #19 (close됨)
- 관련 PRs: #20, #21, #22, #23, #25 (모두 머지됨)
- PR #24에서 새로 추가된 "HANDOFF.md 갱신 권유" 트리거에 따라 이 PR을 분리해 처리
- 코드 변경이 없어 CI는 lint/format만 검증

🤖 Generated with [Claude Code](https://claude.com/claude-code)