### PR TITLE
feat: 크롤링 스케줄러 (#13) — Route Handler + GHA 1시간 cron

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,3 +3,8 @@
 # SUPABASE_SERVICE_ROLE_KEY: never expose to client, never commit
 SUPABASE_URL=
 SUPABASE_SERVICE_ROLE_KEY=
+
+# Cron trigger shared secret
+# Used by /api/cron/crawl to authorize scheduled invocations (GitHub Actions / curl)
+# Register the same value in Vercel env and GitHub repo secrets; never commit
+CRON_SECRET=

--- a/.github/workflows/crawl.yml
+++ b/.github/workflows/crawl.yml
@@ -1,0 +1,24 @@
+name: Crawl
+
+on:
+  schedule:
+    - cron: '0 * * * *'
+  workflow_dispatch:
+
+concurrency:
+  group: crawl
+  cancel-in-progress: false
+
+jobs:
+  trigger:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger /api/cron/crawl
+        env:
+          DEPLOY_URL: ${{ secrets.DEPLOY_URL }}
+          CRON_SECRET: ${{ secrets.CRON_SECRET }}
+        run: |
+          curl --fail --show-error --silent \
+            --max-time 120 \
+            -H "Authorization: Bearer ${CRON_SECRET}" \
+            "${DEPLOY_URL%/}/api/cron/crawl"

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -5,7 +5,7 @@
 
 ---
 
-## 0. 최신 상태 (2026-06-01 기준)
+## 0. 최신 상태 (2026-06-05 기준)
 
 ### 완료된 Step
 
@@ -21,19 +21,22 @@
 | Step 6      | 데이터 소스 재설계: JSON API(주) + view.do(gap 보강) 하이브리드 (epic #19, PR #20~23, #25 머지)                                                                                                                                                  | `src/lib/crawler/parseListJson.ts`, `fetchJsonText.ts`, `isViewErrorPage.ts`, `announcementService.ts` 재작성, `__fixtures__/{listJson.json,viewErrorPage.html,detailPage.html}` 실 응답 박제. 결정 근거는 ADR 002/003. 기존 `parseMainPage.ts`/`checkBoardId.ts` 폐기 표기 (실제 제거는 PR #27)                                                                                                      |
 | Step 6 정리 | epic #19 후속 정리 (PR #27 머지): #12·#13 이슈 본문을 옵션 B / GHA 기준으로 다듬고, 폐기 표기된 `checkBoardId` 모듈 실제 삭제                                                                                                                    | `src/lib/crawler/checkBoardId.ts`(+`.test.ts`) 삭제, `src/lib/crawler/index.ts` export 정리. 단위·통합 테스트 49개 그린 (checkBoardId.test.ts 9개 제거 영향)                                                                                                                                                                                                                                          |
 | Step 7      | Supabase 저장 통합 (#12 완료): admin 클라이언트 + `announcements` UPSERT 리포지터리 + `crawl_state` 리포지터리 + `announcementService` 저장 연결. `crawl_state` 갱신 호출은 #13 스케줄러 통합 시점에 연결 예정                                   | `src/lib/supabase/{client.ts, announcementsRepository.ts(+.test.ts), crawlStateRepository.ts(+.test.ts)}`, `src/lib/crawler/announcementService.ts` 갱신, `.env.example`, `docs/learning/{step7-supabase-client.md, step7-repository-pattern.md, step7-mocking-supabase.md}`. PR #29 (1차 통합) + PR #30 (cleanup — 테스트 백필 + crawl_state + env 문서화 + 학습 정리). 테스트 61개 그린             |
+| Step 8      | 크롤링 스케줄러 (#13): `/api/cron/crawl` Route Handler + `.github/workflows/crawl.yml` (1시간 cron + `workflow_dispatch` + `curl --fail`). `CRON_SECRET` Bearer 인증, `crawlStateRepository.updateLastBoardId` 연결까지 완료                     | `src/app/api/cron/crawl/{route.ts, route.test.ts}` (인증 4종 + 정상 흐름 + 실패 케이스, 66개 그린), `.github/workflows/crawl.yml`, `.env.example`(`CRON_SECRET` 추가), `README.md`(운영 섹션 — 시크릿 등록 + 수동/로컬 트리거), `docs/learning/step8-gha-cron-vercel-trigger.md`. 결정 근거는 ADR 004                                                                                                 |
 | 학습 정리   | Sprint 1 학습 문서 정책 정리 (PR #31 머지): `docs/learning/`을 "다른 프로젝트에도 가져갈 보편 패턴"만 보존하도록 통합. 청안 고유 판단(특정 사이트 응답 패턴, 매핑 정책, 단일행 트리비얼 필터 등)은 ADR/코드 주석으로 이관. CLAUDE.md에 정책 반영 | `docs/learning/{step2-project-init, step4-crawling, step5-service-layer, step6-data-source-redesign}.md` 통합·삭제, `step4-{cheerio, vitest-basics, db-basics}.md` 신설, `step5-{fetch-html, msw-testing}.md`·`step7-*.md` 3종에서 청안 고유 절 제거. `step7-supabase-client.md`는 실제 `client.ts`와 정합 정정(싱글톤 캐시, 변수별 throw, autoRefreshToken 등). CLAUDE.md `docs/learning/` 정책 갱신 |
 | ADR 001     | 기술 스택 선정 근거 문서화                                                                                                                                                                                                                       | `docs/adr/001-tech-stack.md`                                                                                                                                                                                                                                                                                                                                                                          |
 | ADR 002     | 크롤링 데이터 소스 전략 — 옵션 비교 + C(하이브리드) 채택                                                                                                                                                                                         | `docs/adr/002-crawling-data-source.md`                                                                                                                                                                                                                                                                                                                                                                |
 | ADR 003     | 저장 매핑 전략 — 옵션 B (저장 전 view.do 보강) 채택. ADR 002 옵션 C 하이브리드를 "JSON으로 신규 감지 + 모든 신규는 view.do로 detail 확보" 패턴으로 좁힘                                                                                          | `docs/adr/003-storage-mapping-strategy.md`                                                                                                                                                                                                                                                                                                                                                            |
 | ADR 004     | 크롤링 스케줄러 선택 — GitHub Actions 채택 (1시간 간격, Hobby 플랜 무료)                                                                                                                                                                         | `docs/adr/004-scheduler-choice.md`                                                                                                                                                                                                                                                                                                                                                                    |
 
-### 진행 중: Sprint 1 잔여
+### 진행 중: Sprint 1 마무리
 
-크롤링 파이프라인 본체(데이터 소스 재설계 포함)와 Supabase 저장 통합(#12)까지 완료. 매핑 전략(ADR 003)·스케줄러(ADR 004)는 결정 완료. 남은 건 스케줄러 트리거(#13) 구현.
+크롤링 파이프라인 본체(데이터 소스 재설계 포함) + Supabase 저장 통합(#12) + 스케줄러(#13)까지 모두 구현 완료. Sprint 1의 기능 범위는 종료. 남은 건 운영 시크릿 등록과 회고.
 
-### 다음 할 일 (Sprint 1 잔여)
+### 다음 할 일
 
-1. **#13 스케줄러** — `/api/cron/crawl` Route Handler + `.github/workflows/crawl.yml` (1시간 간격, `CRON_SECRET` Bearer 인증). ADR 004 적용. Route Handler에서 `announcementService` 호출 후 `crawlStateRepository.updateLastBoardId` 연결
+1. **운영 시크릿 등록** — Vercel(`SUPABASE_URL`, `SUPABASE_SERVICE_ROLE_KEY`, `CRON_SECRET`) + GitHub Secrets(`CRON_SECRET` 동일 값, `DEPLOY_URL`). README "운영" 섹션 참고
+2. **첫 cron 실행 검증** — GitHub Actions의 `Crawl` 워크플로우를 `workflow_dispatch`로 1회 수동 트리거 → 응답 페이로드(`newCount`, `latestBoardId`)와 DB 반영 확인
+3. **Sprint 1 회고** — `docs/retrospectives/TEMPLATE.md` 양식으로 회고 작성. Phase 1 Sprint 1 (#11/#12/#13) 종료 시점
 
 ### 용어 매핑
 

--- a/README.md
+++ b/README.md
@@ -53,6 +53,42 @@ pnpm test
 pnpm build
 ```
 
+## 운영
+
+### 크롤링 스케줄러 (#13)
+
+1시간 간격으로 `/api/cron/crawl`을 호출해 새 공고를 수집한다.
+스케줄러는 GitHub Actions(`.github/workflows/crawl.yml`)에서 동작하며,
+배포된 Vercel 엔드포인트를 `Authorization: Bearer $CRON_SECRET`으로 트리거한다.
+근거는 [ADR 004](./docs/adr/004-scheduler-choice.md).
+
+#### 시크릿 등록 (최초 1회)
+
+| 위치            | 키                          | 값                                                   |
+| --------------- | --------------------------- | ---------------------------------------------------- |
+| Vercel 환경변수 | `SUPABASE_URL`              | Supabase Project Settings → API                      |
+| Vercel 환경변수 | `SUPABASE_SERVICE_ROLE_KEY` | 동일 (server-side, 클라이언트 노출 금지)             |
+| Vercel 환경변수 | `CRON_SECRET`               | 임의 난수 (예: `openssl rand -hex 32`)               |
+| GitHub Secrets  | `CRON_SECRET`               | **Vercel과 동일 값**                                 |
+| GitHub Secrets  | `DEPLOY_URL`                | Vercel 배포 URL (예: `https://cheong-an.vercel.app`) |
+
+토큰 불일치 호출은 401로 거부된다. `CRON_SECRET`을 회전하면 두 곳을 함께 갱신한다.
+
+#### 수동 트리거
+
+GitHub Actions의 `Crawl` 워크플로우에서 **Run workflow** 버튼으로 즉시 실행 가능.
+
+#### 로컬 트리거
+
+`.env.local`에 `CRON_SECRET=dev-secret`을 두고 dev 서버 기동 후:
+
+```bash
+curl --fail -H "Authorization: Bearer dev-secret" \
+  http://localhost:3000/api/cron/crawl
+```
+
+응답: `{ newCount, skippedBoardIds, latestBoardId }`.
+
 ## 라이선스
 
 [MIT](./LICENSE)

--- a/docs/learning/step8-gha-cron-vercel-trigger.md
+++ b/docs/learning/step8-gha-cron-vercel-trigger.md
@@ -1,0 +1,262 @@
+# Step 8: GitHub Actions cron + Vercel Route Handler 트리거 — 학습 정리
+
+> 외부 스케줄러에서 배포된 앱의 엔드포인트를 주기적으로 호출하는 패턴.
+> 다른 프로젝트에도 그대로 적용 가능한 보편 패턴만 정리한다.
+> 청안의 구체적 판단(왜 GHA를 골랐는지, 왜 1시간 간격인지)은 [ADR 004](../adr/004-scheduler-choice.md) 참고.
+
+---
+
+## 목차
+
+1. [수행한 작업 요약](#1-수행한-작업-요약)
+2. [외부 트리거 패턴: 스케줄러와 핸들러의 분리](#2-외부-트리거-패턴-스케줄러와-핸들러의-분리)
+3. [GitHub Actions `schedule` 트리거](#3-github-actions-schedule-트리거)
+4. [`workflow_dispatch` — 수동 트리거의 가치](#4-workflow_dispatch--수동-트리거의-가치)
+5. [`curl --fail`이 워크플로우 실패와 연결되는 방식](#5-curl---fail이-워크플로우-실패와-연결되는-방식)
+6. [`concurrency` 그룹](#6-concurrency-그룹)
+7. [Next.js Route Handler의 `dynamic = 'force-dynamic'`](#7-nextjs-route-handler의-dynamic--force-dynamic)
+8. [Bearer 토큰으로 외부 트리거 보호하기](#8-bearer-토큰으로-외부-트리거-보호하기)
+
+---
+
+## 1. 수행한 작업 요약
+
+| 파일                              | 작업 | 목적                                                                                 |
+| --------------------------------- | ---- | ------------------------------------------------------------------------------------ |
+| `src/app/api/cron/crawl/route.ts` | 생성 | Bearer 인증 → 크롤 → DB UPSERT → 상태 갱신을 수행하는 Route Handler                  |
+| `.github/workflows/crawl.yml`     | 생성 | 1시간 간격 `schedule` + `workflow_dispatch`로 위 엔드포인트를 `curl --fail`로 트리거 |
+| `.env.example`                    | 갱신 | `CRON_SECRET` 항목 추가                                                              |
+| `README.md`                       | 갱신 | 시크릿 등록(Vercel/GH Secrets), 수동/로컬 트리거 절차 명시                           |
+
+**결과**: 외부 스케줄러(GHA)가 1시간마다 배포된 엔드포인트를 인증 토큰과 함께 호출한다. 토큰이 없거나 다르면 401로 거부된다.
+
+---
+
+## 2. 외부 트리거 패턴: 스케줄러와 핸들러의 분리
+
+서버리스 환경(Vercel, Cloudflare Workers, Netlify 등)은 **항상 떠 있는 프로세스가 없다**. "1시간마다 무언가를 실행"하려면 두 가지 중 하나가 필요하다:
+
+1. **플랫폼 내장 cron**: Vercel Cron, Cloudflare Cron Triggers 등 — 같은 플랫폼 안에서 닫힘.
+2. **외부 스케줄러 + HTTP 호출**: GitHub Actions, EventBridge, n8n, cron-job.org 등 → 배포된 엔드포인트를 호출.
+
+이번 패턴은 (2)다. 구조:
+
+```
+외부 스케줄러 ──HTTP──▶ /api/cron/* (앱 내 핸들러) ──▶ 비즈니스 로직
+   (시간 트리거)         (인증 + 실행)
+```
+
+핵심 분리:
+
+- **스케줄러는 "언제 시작할지"만 안다**. 무엇을 할지는 모름. 그저 URL을 친다.
+- **핸들러는 "무엇을 할지"만 안다**. 누가 깨우든 상관없이 자기 일을 한다.
+
+이 분리의 장점:
+
+- 스케줄러를 다른 도구로 갈아끼울 수 있다(GHA → EventBridge 등). URL만 같으면 된다.
+- 핸들러를 수동으로도 호출할 수 있다(개발 시 curl, 운영 시 워크플로우 수동 실행).
+- 호스팅 플랫폼을 옮겨도 워크플로우는 그대로(URL만 갱신).
+
+단점: 외부 경계를 거치므로 **인증 토큰이 필수**다. (8장 참조)
+
+---
+
+## 3. GitHub Actions `schedule` 트리거
+
+```yaml
+on:
+  schedule:
+    - cron: '0 * * * *'
+```
+
+### cron 표현식
+
+5개 필드: `분 시 일 월 요일`. 위 표현은 "매시 0분에".
+
+| 표현           | 의미                 |
+| -------------- | -------------------- |
+| `0 * * * *`    | 매시 0분             |
+| `*/15 * * * *` | 15분마다             |
+| `0 9 * * 1-5`  | 평일 오전 9시        |
+| `0 0 * * 0`    | 매주 일요일 자정 UTC |
+
+**시간대는 UTC**. 한국 시간(KST = UTC+9)으로 매일 아침 9시에 실행하려면 `0 0 * * *`(UTC 00시 = KST 09시)로 적는다.
+
+### 정확도와 지연
+
+GitHub Actions의 schedule은 **정확하지 않다**. 공식적으로 ±수 분 지연이 발생할 수 있고, 부하가 높을 때는 더 늘어진다. 분 단위 정확성을 요구하는 작업(예: 특정 시각에 메시지 발송)에는 부적합. 시간 단위 작업(예: 1시간마다 크롤링)은 무관.
+
+### Public repo vs private
+
+- Public repo: 사실상 무제한.
+- Private repo: 무료 분 사용량(예: 2000분/월)에서 차감.
+
+---
+
+## 4. `workflow_dispatch` — 수동 트리거의 가치
+
+```yaml
+on:
+  schedule:
+    - cron: '0 * * * *'
+  workflow_dispatch:
+```
+
+`workflow_dispatch`를 추가하면 GitHub UI에 **Run workflow** 버튼이 생긴다. 또는 `gh workflow run`으로 CLI 트리거도 가능.
+
+왜 같이 두는가:
+
+- **디버깅**: schedule 트리거가 실패했을 때 같은 워크플로우를 즉시 재실행해 원인 확인.
+- **운영 개입**: "지금 한 번 더 돌려달라"는 요구를 코드 변경 없이 처리.
+- **테스트**: 스케줄을 기다리지 않고 워크플로우 자체의 동작을 검증.
+
+스케줄 트리거만 있고 수동 트리거가 없으면, 워크플로우 변경 후 "지금 동작하는지" 확인하기 위해 cron 다음 발화를 기다리거나 cron 표현식을 임시로 바꿔야 한다. 비용 거의 0인데 운영 효율은 크게 오르므로 **schedule을 쓸 때는 항상 같이 둔다**.
+
+---
+
+## 5. `curl --fail`이 워크플로우 실패와 연결되는 방식
+
+```bash
+curl --fail --show-error --silent \
+  --max-time 120 \
+  -H "Authorization: Bearer ${CRON_SECRET}" \
+  "${DEPLOY_URL}/api/cron/crawl"
+```
+
+### `--fail`의 의미
+
+`--fail`이 없으면 curl은 HTTP 응답 상태(200/400/500 등)와 **무관하게 성공 종료(exit 0)** 한다. 응답 본문은 출력되지만 셸 입장에서는 "curl이 응답을 받았다"로 성공.
+
+`--fail`을 붙이면 4xx/5xx 응답에서 **curl이 exit 22로 비정상 종료**한다. GHA 워크플로우의 step은 마지막 명령의 exit code로 성공/실패를 판단하므로, 이 한 줄로 "HTTP 에러 = 워크플로우 실패"가 연결된다.
+
+### 동반 플래그
+
+- `--show-error`: `--silent`로 진행 표시를 숨겨도 에러 메시지는 표시.
+- `--silent`: 진행률 막대 등 잡음을 제거 (CI 로그 정리).
+- `--max-time 120`: 응답이 120초를 넘으면 강제 종료 → 무한 대기 방지.
+
+### 함정: HTTP 200이지만 응답 본문이 에러
+
+`--fail`은 HTTP 상태 코드만 본다. 핸들러가 내부 에러를 200 + `{ error: ... }`로 응답하면 curl은 성공이라고 판단한다.
+
+→ **핸들러 측에서 실패는 반드시 4xx/5xx로 응답**하는 규약이 전제다. (route.ts에서 인증 실패 401, 내부 예외 500을 쓰는 이유)
+
+---
+
+## 6. `concurrency` 그룹
+
+```yaml
+concurrency:
+  group: crawl
+  cancel-in-progress: false
+```
+
+### 동작
+
+같은 `group` 이름의 워크플로우 실행은 **동시에 하나만** 진행된다.
+
+- `cancel-in-progress: true` — 새 트리거가 들어오면 기존 실행을 취소하고 새 것으로 교체. **CI에 적합**(같은 PR의 새 push를 검증하면 충분).
+- `cancel-in-progress: false` — 기존 실행을 그대로 두고 새 트리거는 큐잉. **주기 작업에 적합**(작업 자체를 끊으면 중간 상태가 남을 수 있음).
+
+### 왜 cron에 concurrency가 필요한가
+
+이론적으로 1시간 간격이라 충돌이 없어 보이지만:
+
+- 실행 시간이 길어져 다음 cron 발화와 겹칠 수 있음.
+- `workflow_dispatch`로 수동 트리거할 때 schedule과 겹칠 수 있음.
+- 두 실행이 동시에 같은 DB에 쓰면 경쟁 조건 위험.
+
+→ `cancel-in-progress: false`로 직렬화. 큐잉된 두 번째 실행은 첫 번째가 끝나면 자동 시작.
+
+---
+
+## 7. Next.js Route Handler의 `dynamic = 'force-dynamic'`
+
+```ts
+export const dynamic = 'force-dynamic';
+
+export async function GET(request: Request) { ... }
+```
+
+### 배경: Next.js의 자동 최적화
+
+Next.js App Router의 Route Handler는 빌드 타임에 **정적으로 최적화**될 수 있다. 즉, 빌드 시 한 번 실행해 결과를 캐시하고, 이후 모든 요청에 같은 응답을 돌려준다. 같은 입력에 같은 출력을 주는 핸들러에서는 합리적이다.
+
+### cron 엔드포인트에서 문제가 되는 이유
+
+cron 엔드포인트는 호출될 때마다 **새로 크롤링하고 DB를 갱신**해야 한다. 빌드 타임에 캐시되면:
+
+- 매 호출마다 같은 결과가 반환되어 실제 크롤링이 동작하지 않음.
+- DB 갱신도 일어나지 않음.
+
+### `force-dynamic`의 효과
+
+`export const dynamic = 'force-dynamic'`을 선언하면 Next.js는 이 핸들러를 **항상 요청 시점에 실행**하도록 강제한다. 캐싱·정적화·서버 컴포넌트의 RSC 캐시를 모두 우회.
+
+### 언제 필요한가
+
+이 플래그가 필요한 핸들러의 공통점:
+
+- 외부 상태(DB, 외부 API)를 읽거나 쓰는 핸들러.
+- 시간 또는 요청별로 결과가 달라져야 하는 핸들러.
+- 사이드 이펙트가 있는 핸들러(cron, 웹훅 수신 등).
+
+GET이라도 사이드 이펙트가 있으면 동적이어야 한다.
+
+---
+
+## 8. Bearer 토큰으로 외부 트리거 보호하기
+
+cron 엔드포인트는 인터넷에 노출된 URL이다. 누구나 발견하면 호출할 수 있고, 호출 비용·DB 부하·외부 사이트 부하가 모두 우리 비용이 된다.
+
+### 최소 보호: 공유 시크릿 + Bearer 헤더
+
+```ts
+const secret = process.env.CRON_SECRET;
+const header = request.headers.get('authorization');
+if (header !== `Bearer ${secret}`) {
+  return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+}
+```
+
+스케줄러 측은 같은 토큰을 헤더로 붙여서 호출한다:
+
+```bash
+curl -H "Authorization: Bearer $CRON_SECRET" $URL/api/cron/...
+```
+
+### 시크릿 등록의 이중성
+
+이 패턴은 **같은 값을 두 곳에 둔다**:
+
+| 위치              | 키            | 역할               |
+| ----------------- | ------------- | ------------------ |
+| 앱 호스트(Vercel) | `CRON_SECRET` | 들어오는 요청 검증 |
+| 스케줄러(GH)      | `CRON_SECRET` | 나가는 요청에 부착 |
+
+두 곳 중 한쪽만 갱신하면 401로 끊긴다. **회전(rotation) 시에는 항상 두 곳 동시에**.
+
+### 왜 이걸로 "충분한가"
+
+이 보호는 약하지만 합리적이다:
+
+- HTTPS로 토큰이 평문 노출되지 않음.
+- 토큰을 모르면 401로 거부 → 실행 비용·DB 부하 0.
+- Replay 공격은 가능하지만, 매시간 1회 호출이 추가로 일어나도 시스템적 의미는 없음.
+
+더 엄격하게 가야 할 경우(예: 결제 트리거): 시간 기반 서명(HMAC + timestamp + nonce), mTLS, IP allowlist 등을 더한다. cron 트리거 정도에는 과한 투자.
+
+### 환경변수 누락 시의 처리
+
+`CRON_SECRET`이 비어 있을 때 인증을 건너뛰면 **사실상 보호가 사라진 채 운영**되는 위험이 있다. 안전한 디폴트는:
+
+```ts
+if (!secret) {
+  return NextResponse.json(
+    { error: 'CRON_SECRET is not configured' },
+    { status: 500 },
+  );
+}
+```
+
+빈 시크릿이면 차라리 핸들러가 500으로 죽도록 한다. "조용히 보호가 풀린" 상태보다 "시끄럽게 실패"가 안전하다.

--- a/src/app/api/cron/crawl/route.test.ts
+++ b/src/app/api/cron/crawl/route.test.ts
@@ -1,0 +1,168 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { AnnouncementDetail } from '@/types/announcement';
+
+vi.mock('@/lib/crawler/announcementService', () => ({
+  crawlNewAnnouncements: vi.fn(),
+}));
+vi.mock('@/lib/supabase/client', () => ({
+  getSupabaseAdminClient: vi.fn(),
+}));
+vi.mock('@/lib/supabase/announcementsRepository', () => ({
+  upsertAnnouncements: vi.fn(),
+}));
+vi.mock('@/lib/supabase/crawlStateRepository', () => ({
+  getLastBoardId: vi.fn(),
+  updateLastBoardId: vi.fn(),
+}));
+
+import { crawlNewAnnouncements } from '@/lib/crawler/announcementService';
+import { upsertAnnouncements } from '@/lib/supabase/announcementsRepository';
+import { getSupabaseAdminClient } from '@/lib/supabase/client';
+import {
+  getLastBoardId,
+  updateLastBoardId,
+} from '@/lib/supabase/crawlStateRepository';
+
+import { GET } from './route';
+
+function buildDetail(boardId: number): AnnouncementDetail {
+  return {
+    boardId,
+    title: `공고 ${boardId}`,
+    announcementType: 'public',
+    recruitmentType: 'initial',
+    complexName: null,
+    district: null,
+    address: null,
+    totalUnits: null,
+    postDate: '2026-05-01',
+    applicationStartDate: null,
+    applicationEndDate: null,
+    resultDate: null,
+    attachmentUrl: null,
+    attachmentName: null,
+    rawContent: '',
+  };
+}
+
+function makeRequest(authHeader?: string): Request {
+  const headers: Record<string, string> = {};
+  if (authHeader !== undefined) headers.authorization = authHeader;
+  return new Request('http://localhost/api/cron/crawl', {
+    method: 'GET',
+    headers,
+  });
+}
+
+const ORIGINAL_SECRET = process.env.CRON_SECRET;
+
+describe('GET /api/cron/crawl', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.CRON_SECRET = 'test-secret';
+  });
+
+  afterEach(() => {
+    if (ORIGINAL_SECRET === undefined) {
+      delete process.env.CRON_SECRET;
+    } else {
+      process.env.CRON_SECRET = ORIGINAL_SECRET;
+    }
+  });
+
+  it('CRON_SECRET 미설정 시 500', async () => {
+    delete process.env.CRON_SECRET;
+
+    const response = await GET(makeRequest('Bearer anything'));
+
+    expect(response.status).toBe(500);
+    expect(await response.json()).toEqual({
+      error: 'CRON_SECRET is not configured',
+    });
+    expect(crawlNewAnnouncements).not.toHaveBeenCalled();
+  });
+
+  it('Authorization 헤더 누락 시 401', async () => {
+    const response = await GET(makeRequest());
+
+    expect(response.status).toBe(401);
+    expect(await response.json()).toEqual({ error: 'Unauthorized' });
+    expect(crawlNewAnnouncements).not.toHaveBeenCalled();
+  });
+
+  it('Bearer 토큰 값 불일치 시 401', async () => {
+    const response = await GET(makeRequest('Bearer wrong-secret'));
+
+    expect(response.status).toBe(401);
+    expect(crawlNewAnnouncements).not.toHaveBeenCalled();
+  });
+
+  it('정상 흐름: 호출 순서 + 응답 페이로드', async () => {
+    const client = {} as unknown as ReturnType<typeof getSupabaseAdminClient>;
+    vi.mocked(getSupabaseAdminClient).mockReturnValue(client);
+    vi.mocked(getLastBoardId).mockResolvedValue(100);
+    vi.mocked(crawlNewAnnouncements).mockResolvedValue({
+      newDetails: [buildDetail(101), buildDetail(103)],
+      latestBoardId: 103,
+      skippedBoardIds: [102],
+    });
+    vi.mocked(upsertAnnouncements).mockResolvedValue();
+    vi.mocked(updateLastBoardId).mockResolvedValue();
+
+    const response = await GET(makeRequest('Bearer test-secret'));
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      newCount: 2,
+      skippedBoardIds: [102],
+      latestBoardId: 103,
+    });
+
+    expect(getLastBoardId).toHaveBeenCalledWith(client);
+    expect(crawlNewAnnouncements).toHaveBeenCalledWith({ lastBoardId: 100 });
+    expect(upsertAnnouncements).toHaveBeenCalledWith(client, [
+      buildDetail(101),
+      buildDetail(103),
+    ]);
+    expect(updateLastBoardId).toHaveBeenCalledWith(client, 103);
+
+    // getLast → crawl → upsert → updateLast 순서 보장
+    const getLastOrder = vi.mocked(getLastBoardId).mock.invocationCallOrder[0];
+    const crawlOrder = vi.mocked(crawlNewAnnouncements).mock
+      .invocationCallOrder[0];
+    const upsertOrder =
+      vi.mocked(upsertAnnouncements).mock.invocationCallOrder[0];
+    const updateOrder =
+      vi.mocked(updateLastBoardId).mock.invocationCallOrder[0];
+    expect(getLastOrder).toBeLessThan(crawlOrder);
+    expect(crawlOrder).toBeLessThan(upsertOrder);
+    expect(upsertOrder).toBeLessThan(updateOrder);
+  });
+
+  it('upsert 실패 시 500 + 메시지 노출, updateLastBoardId 호출 안 됨', async () => {
+    vi.mocked(getSupabaseAdminClient).mockReturnValue(
+      {} as unknown as ReturnType<typeof getSupabaseAdminClient>,
+    );
+    vi.mocked(getLastBoardId).mockResolvedValue(100);
+    vi.mocked(crawlNewAnnouncements).mockResolvedValue({
+      newDetails: [buildDetail(101)],
+      latestBoardId: 101,
+      skippedBoardIds: [],
+    });
+    vi.mocked(upsertAnnouncements).mockRejectedValue(new Error('db down'));
+
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const response = await GET(makeRequest('Bearer test-secret'));
+
+    expect(response.status).toBe(500);
+    expect(await response.json()).toEqual({
+      error: 'Crawl failed',
+      message: 'db down',
+    });
+    expect(updateLastBoardId).not.toHaveBeenCalled();
+
+    errSpy.mockRestore();
+  });
+});

--- a/src/app/api/cron/crawl/route.ts
+++ b/src/app/api/cron/crawl/route.ts
@@ -1,0 +1,71 @@
+/**
+ * 크롤링 트리거 엔드포인트 (#13).
+ *
+ * 호출자: GitHub Actions scheduled workflow (ADR 004).
+ *   `curl --fail -H "Authorization: Bearer $CRON_SECRET" $DEPLOY_URL/api/cron/crawl`
+ *
+ * 흐름:
+ *   1. Bearer 토큰 검증 (CRON_SECRET).
+ *   2. crawl_state.last_board_id 조회.
+ *   3. JSON+view.do 하이브리드로 신규 detail 확보 (ADR 002/003).
+ *   4. announcements UPSERT.
+ *   5. crawl_state.last_board_id / last_crawled_at 갱신.
+ *   6. JSON 응답: { newCount, skippedBoardIds, latestBoardId }.
+ *
+ * 에러 매핑:
+ *   - 401: 토큰 누락 또는 불일치.
+ *   - 500: CRON_SECRET 미설정 또는 크롤러/DB 예외.
+ *
+ * 캐싱: cron 트리거이므로 dynamic = 'force-dynamic'으로 매 호출 실행 보장.
+ */
+
+import { NextResponse } from 'next/server';
+
+import { crawlNewAnnouncements } from '@/lib/crawler/announcementService';
+import { upsertAnnouncements } from '@/lib/supabase/announcementsRepository';
+import { getSupabaseAdminClient } from '@/lib/supabase/client';
+import {
+  getLastBoardId,
+  updateLastBoardId,
+} from '@/lib/supabase/crawlStateRepository';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET(request: Request): Promise<NextResponse> {
+  const secret = process.env.CRON_SECRET;
+  if (!secret) {
+    return NextResponse.json(
+      { error: 'CRON_SECRET is not configured' },
+      { status: 500 },
+    );
+  }
+
+  const header = request.headers.get('authorization');
+  if (header !== `Bearer ${secret}`) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  try {
+    const client = getSupabaseAdminClient();
+    const lastBoardId = await getLastBoardId(client);
+
+    const { newDetails, latestBoardId, skippedBoardIds } =
+      await crawlNewAnnouncements({ lastBoardId });
+
+    await upsertAnnouncements(client, newDetails);
+    await updateLastBoardId(client, latestBoardId);
+
+    return NextResponse.json({
+      newCount: newDetails.length,
+      skippedBoardIds,
+      latestBoardId,
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Unknown error';
+    console.error('[cron/crawl] failed:', err);
+    return NextResponse.json(
+      { error: 'Crawl failed', message },
+      { status: 500 },
+    );
+  }
+}


### PR DESCRIPTION
## Summary

#13 닫음. ADR 004(GitHub Actions 스케줄러) 적용 — `/api/cron/crawl` Route Handler를 1시간 간격으로 외부에서 Bearer 토큰으로 트리거하는 구조.

## 주요 변경 사항

### 1. Route Handler (`feat: 9cbfd60`)

- `src/app/api/cron/crawl/route.ts` 신규
- 흐름: Bearer 인증 → `crawlNewAnnouncements({ lastBoardId })` → `upsertAnnouncements` → `updateLastBoardId`
- 응답: `{ newCount, skippedBoardIds, latestBoardId }`
- 실패 정책: 인증 실패 401 / 환경설정 누락·내부 예외 500 → `curl --fail`이 워크플로우 실패로 연결
- `dynamic = 'force-dynamic'`으로 캐싱 우회
- `route.test.ts`: 인증 4종(미설정·헤더 누락·토큰 불일치·정상) + 정상 흐름 호출 순서·페이로드 + upsert 실패 시 500 + `updateLastBoardId` 미호출 검증 (66/66 그린)

### 2. GitHub Actions 워크플로우 (`chore: d7d10b1`)

- `.github/workflows/crawl.yml` 신규
- `schedule: '0 * * * *'` + `workflow_dispatch`(수동 트리거)
- `curl --fail --show-error --silent --max-time 120 -H "Authorization: Bearer ${CRON_SECRET}" "${DEPLOY_URL}/api/cron/crawl"`
- `concurrency.group: crawl`, `cancel-in-progress: false` — schedule × workflow_dispatch 중복 시 직렬화

### 3. 운영 문서 (`chore: d7d10b1`)

- `.env.example`에 `CRON_SECRET` 항목 추가
- README "운영 — 크롤링 스케줄러" 섹션: 시크릿 등록 표(Vercel/GH Secrets), 수동 트리거(GHA Run workflow), 로컬 트리거(curl) 절차

### 4. 학습 문서 (`docs: d96a156`)

- `docs/learning/step8-gha-cron-vercel-trigger.md` 신규
- 보편 패턴만: 외부 스케줄러/핸들러 분리, schedule + workflow_dispatch, `curl --fail`, concurrency, `force-dynamic`, Bearer 토큰
- 청안 고유 판단(왜 GHA / 왜 1시간)은 ADR 004로 분리 유지

### 5. HANDOFF 갱신 (`docs: be1f4a5`)

- Step 8 행 추가, 0. 최신 상태 일자 2026-06-05로 갱신
- 다음 할 일: 시크릿 등록 → 첫 cron 검증 → Sprint 1 회고

## 참고 사항

- 머지 후 운영 시크릿 등록 필요: Vercel(`SUPABASE_URL`, `SUPABASE_SERVICE_ROLE_KEY`, `CRON_SECRET`) + GitHub Secrets(`CRON_SECRET` 동일 값, `DEPLOY_URL`). 절차는 README 참고
- 첫 검증은 GHA의 `Crawl` 워크플로우를 `workflow_dispatch`로 수동 1회 실행해 응답·DB 반영을 확인
- 결정 근거: [ADR 004](./docs/adr/004-scheduler-choice.md)
- closes #13