### PR TITLE
fix: 목록 기반 크롤로 전환해 타 게시판 오염·파이프라인 동결 해소

### DIFF
--- a/src/app/api/cron/crawl/route.test.ts
+++ b/src/app/api/cron/crawl/route.test.ts
@@ -128,6 +128,7 @@ describe('GET /api/cron/crawl', () => {
       newDetails: [buildDetail(101), buildDetail(103)],
       latestBoardId: 103,
       skippedBoardIds: [102],
+      invalidBoardIds: [],
     });
     vi.mocked(upsertAnnouncements).mockResolvedValue();
     vi.mocked(updateLastBoardId).mockResolvedValue();
@@ -138,6 +139,7 @@ describe('GET /api/cron/crawl', () => {
     expect(await response.json()).toEqual({
       newCount: 2,
       skippedBoardIds: [102],
+      invalidBoardIds: [],
       latestBoardId: 103,
     });
 
@@ -171,6 +173,7 @@ describe('GET /api/cron/crawl', () => {
       newDetails: [buildDetail(101)],
       latestBoardId: 101,
       skippedBoardIds: [],
+      invalidBoardIds: [],
     });
     vi.mocked(upsertAnnouncements).mockRejectedValue(new Error('db down'));
 

--- a/src/app/api/cron/crawl/route.ts
+++ b/src/app/api/cron/crawl/route.ts
@@ -8,10 +8,10 @@
  *   1. Bearer 토큰 검증 (CRON_SECRET).
  *   2. 라이브 카나리 검증 (파서 불변식, ADR 006) — 위반 시 즉시 500, 저장 안 함.
  *   3. crawl_state.last_board_id 조회.
- *   4. JSON+view.do 하이브리드로 신규 detail 확보 (ADR 002/003).
- *   5. announcements UPSERT.
+ *   4. 목록 기반 크롤 + view.do 보강으로 신규 detail 확보 (ADR 002/003/007).
+ *   5. announcements UPSERT (불변식 위반 row는 이미 invalidBoardIds로 격리됨).
  *   6. crawl_state.last_board_id / last_crawled_at 갱신.
- *   7. JSON 응답: { newCount, skippedBoardIds, latestBoardId }.
+ *   7. JSON 응답: { newCount, skippedBoardIds, invalidBoardIds, latestBoardId }.
  *
  * 환경변수:
  *   - CRON_SECRET (필수): Bearer 인증.
@@ -70,8 +70,12 @@ export async function GET(request: Request): Promise<NextResponse> {
     const client = getSupabaseAdminClient();
     const lastBoardId = await getLastBoardId(client);
 
-    const { newDetails, latestBoardId, skippedBoardIds } =
+    const { newDetails, latestBoardId, skippedBoardIds, invalidBoardIds } =
       await crawlNewAnnouncements({ lastBoardId });
+
+    if (invalidBoardIds.length > 0) {
+      console.warn('[cron/crawl] 불변식 위반으로 저장 제외:', invalidBoardIds);
+    }
 
     await upsertAnnouncements(client, newDetails);
     await updateLastBoardId(client, latestBoardId);
@@ -79,6 +83,7 @@ export async function GET(request: Request): Promise<NextResponse> {
     return NextResponse.json({
       newCount: newDetails.length,
       skippedBoardIds,
+      invalidBoardIds,
       latestBoardId,
     });
   } catch (err) {

--- a/src/lib/crawler/announcementService.test.ts
+++ b/src/lib/crawler/announcementService.test.ts
@@ -44,9 +44,9 @@ const FAST = {
   },
 };
 
-function buildListJsonText(boardIds: number[]): string {
+function buildListJsonText(boardIds: number[], totPage?: number): string {
   return JSON.stringify({
-    pagingInfo: { totRow: boardIds.length },
+    pagingInfo: { totRow: boardIds.length, ...(totPage ? { totPage } : {}) },
     resultList: boardIds.map((boardId) => ({
       boardId,
       nttSj: `[민간임대] 테스트 공고 ${boardId}`,
@@ -61,6 +61,15 @@ function buildListJsonText(boardIds: number[]): string {
     })),
   });
 }
+
+/**
+ * 공고게시일(view_data)이 없는 상세 페이지 — parseDetailPage가 postDate=''를 내고
+ * checkDetailInvariants의 DETAIL_INVALID_POST_DATE를 위반한다. 633B 에러 페이지는
+ * 아니므로 isViewErrorPage는 통과한다(불변식 게이트 경로 검증용).
+ */
+const invalidDetailHtml =
+  '<html><body><p class="subject">[민간임대] 불변식 위반 공고</p>' +
+  '<div class="board_cont">본문은 있으나 공고게시일 메타가 없음</div></body></html>';
 
 function jsonResponse(text: string, init: ResponseInit = {}) {
   return new HttpResponse(text, {
@@ -144,17 +153,17 @@ describe('crawlNewAnnouncements', () => {
 
     const result = await crawlNewAnnouncements({ ...FAST, lastBoardId: 100 });
 
-    // 옵션 B: JSON 신규 3건 모두 view.do로 호출 (오름차순).
+    // 목록에 있는 신규 3건 모두 view.do로 호출 (오름차순).
     expect(observedBoardIds).toEqual([101, 102, 103]);
     expect(result.newDetails.map((d) => d.boardId)).toEqual([101, 102, 103]);
     expect(result.latestBoardId).toBe(103);
     expect(result.skippedBoardIds).toEqual([]);
   });
 
-  it('JSON에 없는 gap도 신규 boardId 범위에 포함되어 view.do 호출', async () => {
-    // JSON: [103, 100], lastBoardId=99 → 신규 = [100, 101, 102, 103].
-    //   100, 103: JSON에 있어도 view.do로 다시 확인 (옵션 B).
-    //   101, 102: JSON에 없는 gap. view.do 호출.
+  // ADR 007: boardId 전역 시퀀스라 숫자 gap을 채우면 타 게시판 공고가 섞인다.
+  //   목록에 실제 존재하는 boardId만 크롤하고 gap(101, 102)은 건드리지 않는다.
+  it('목록에 없는 boardId(타 게시판/gap)는 크롤하지 않는다', async () => {
+    // JSON: [103, 100], lastBoardId=99 → 신규 후보 = [100, 103] (101, 102 제외).
     const observedBoardIds: number[] = [];
     server.use(
       http.post(LIST_URL, () => jsonResponse(buildListJsonText([103, 100]))),
@@ -169,39 +178,90 @@ describe('crawlNewAnnouncements', () => {
 
     const result = await crawlNewAnnouncements({ ...FAST, lastBoardId: 99 });
 
-    expect(observedBoardIds).toEqual([100, 101, 102, 103]);
-    expect(result.newDetails.map((d) => d.boardId)).toEqual([
-      100, 101, 102, 103,
-    ]);
+    expect(observedBoardIds).toEqual([100, 103]);
+    expect(result.newDetails.map((d) => d.boardId)).toEqual([100, 103]);
     expect(result.latestBoardId).toBe(103);
     expect(result.skippedBoardIds).toEqual([]);
+    expect(result.invalidBoardIds).toEqual([]);
   });
 
   it('신규 일부가 633B면 정상만 newDetails, 나머지는 skippedBoardIds (모두 오름차순)', async () => {
-    // 신규 = [100, 101, 102, 103]. 101은 633B.
+    // 신규 후보 = [100, 103]. 100은 633B.
     server.use(
       http.post(LIST_URL, () => jsonResponse(buildListJsonText([103, 100]))),
-      viewHandler([101]),
+      viewHandler([100]),
     );
 
     const result = await crawlNewAnnouncements({ ...FAST, lastBoardId: 99 });
 
-    expect(result.newDetails.map((d) => d.boardId)).toEqual([100, 102, 103]);
-    expect(result.skippedBoardIds).toEqual([101]);
+    expect(result.newDetails.map((d) => d.boardId)).toEqual([103]);
+    expect(result.skippedBoardIds).toEqual([100]);
     expect(result.latestBoardId).toBe(103);
   });
 
   it('신규 전체가 633B면 newDetails는 비고 skippedBoardIds에 전부', async () => {
     server.use(
       http.post(LIST_URL, () => jsonResponse(buildListJsonText([103, 100]))),
-      viewHandler([100, 101, 102, 103]),
+      viewHandler([100, 103]),
     );
 
     const result = await crawlNewAnnouncements({ ...FAST, lastBoardId: 99 });
 
     expect(result.newDetails).toEqual([]);
-    expect(result.skippedBoardIds).toEqual([100, 101, 102, 103]);
+    expect(result.skippedBoardIds).toEqual([100, 103]);
     expect(result.latestBoardId).toBe(103);
+  });
+
+  // ADR 006/007: 불변식 위반 detail은 저장에서 격리한다 — 단일 불량 row가 배치를
+  //   실패시켜 파이프라인을 동결시키는 것을 막는다. latestBoardId는 그대로 전진.
+  it('불변식 위반 detail은 invalidBoardIds로 격리하고 latestBoardId는 전진', async () => {
+    // 신규 후보 = [100, 101]. 101은 공고게시일이 없어 postDate 불변식 위반.
+    server.use(
+      http.post(LIST_URL, () => jsonResponse(buildListJsonText([101, 100]))),
+      http.get(VIEW_BASE, ({ request }) => {
+        const boardId = Number(
+          new URL(request.url).searchParams.get('boardId'),
+        );
+        return htmlResponse(
+          boardId === 101 ? invalidDetailHtml : detailHtmlFixture,
+        );
+      }),
+    );
+
+    const result = await crawlNewAnnouncements({ ...FAST, lastBoardId: 99 });
+
+    expect(result.newDetails.map((d) => d.boardId)).toEqual([100]);
+    expect(result.invalidBoardIds).toEqual([101]);
+    expect(result.skippedBoardIds).toEqual([]);
+    expect(result.latestBoardId).toBe(101);
+  });
+
+  // ADR 007: 신규가 1페이지(목록 상한)를 넘치면 다음 페이지를 조회해 보전한다.
+  it('신규가 1페이지를 넘으면 totPage 기준 다음 페이지를 조회한다', async () => {
+    // page1: [105,104,103] (totPage=2, 모두 >100 → 경계 못 넘음 → page2 조회)
+    // page2: [102,101,100] (100이 lastBoardId 이하 → 경계 → 중단)
+    // 신규 후보 = [101,102,103,104,105].
+    const listPageIndexes: string[] = [];
+    server.use(
+      http.post(LIST_URL, async ({ request }) => {
+        const params = new URLSearchParams(await request.text());
+        const pageIndex = params.get('pageIndex') ?? '1';
+        listPageIndexes.push(pageIndex);
+        if (pageIndex === '1') {
+          return jsonResponse(buildListJsonText([105, 104, 103], 2));
+        }
+        return jsonResponse(buildListJsonText([102, 101, 100], 2));
+      }),
+      viewHandler(),
+    );
+
+    const result = await crawlNewAnnouncements({ ...FAST, lastBoardId: 100 });
+
+    expect(listPageIndexes).toEqual(['1', '2']);
+    expect(result.newDetails.map((d) => d.boardId)).toEqual([
+      101, 102, 103, 104, 105,
+    ]);
+    expect(result.latestBoardId).toBe(105);
   });
 
   it('view.do detail은 complexName/district 등 풍부 필드를 보존', async () => {

--- a/src/lib/crawler/announcementService.ts
+++ b/src/lib/crawler/announcementService.ts
@@ -1,13 +1,18 @@
 /**
- * 크롤링 파이프라인 합성 레이어 (ADR 003 옵션 B 반영).
+ * 크롤링 파이프라인 합성 레이어 (ADR 007 — 목록 기반 크롤).
  *
  * 책임 범위:
- * - JSON 목록 API(bbsListJson.json) 1회 호출로 latestBoardId 산출.
- * - 신규 boardId 전체(= lastBoardId+1 ~ latestBoardId)를 view.do로 직접 호출해
- *   완전한 AnnouncementDetail을 얻는다. JSON 응답에 있든(신규) 없든(gap) 모두 view.do 통일.
+ * - JSON 목록 API(bbsListJson.json)를 호출해 BMSR00015에 실제 존재하는
+ *   boardId만 신규 후보로 삼는다. boardId는 게시판을 가로지르는 전역 시퀀스라
+ *   숫자 gap을 채우면 타 게시판(BMSR00013 등) 공고가 섞이므로 gap-fill을 폐기한다.
+ * - 폴링 사이 1페이지를 넘겨 밀려난 신규를 보전하기 위해, 페이지 최소 boardId가
+ *   아직 lastBoardId보다 크고 다음 페이지가 있으면 추가 페이지를 조회한다.
+ * - 신규 boardId마다 view.do를 호출해 완전한 AnnouncementDetail을 얻는다(ADR 003 옵션 B).
  * - 633B 에러 페이지는 skippedBoardIds로 분리.
- * - 각 호출에 rateLimit과 retry를 일관되게 적용.
- * - 호출 순서는 boardId 오름차순 (디버깅·재시도 추적 단순화).
+ * - 저장 전 파서 불변식(checkDetailInvariants)을 통과하지 못한 detail은
+ *   invalidBoardIds로 격리한다 — 단일 불량 row가 배치 전체를 실패시켜 파이프라인을
+ *   동결시키는 것을 막는다(ADR 006/007).
+ * - 각 호출에 rateLimit과 retry를 일관되게 적용. 호출 순서는 boardId 오름차순.
  * - 부트스트랩(lastBoardId=0)에서는 catch-up 루프를 건너뛰고 latestBoardId만 반환
  *   (ADR 005).
  *
@@ -23,16 +28,24 @@
  * - ADR 002 옵션 C (하이브리드 데이터 소스 — JSON 주 + view.do 보강).
  * - ADR 003 옵션 B (저장 전 view.do 보강 → 모든 신규는 detail로 통일).
  * - ADR 005 (lastBoardId=0이면 부트스트랩으로 catch-up 생략).
+ * - ADR 007 (전역 boardId gap-fill 폐기, 목록에 존재하는 boardId만 크롤).
  */
 
 import { fetchHtml, type FetchHtmlOptions } from './fetchHtml';
 import { fetchJsonText, type FetchJsonOptions } from './fetchJsonText';
 import { withRetry, type RetryOptions } from './retry';
 import { createRateLimiter, type RateLimiter } from './rateLimit';
-import { parseListJson } from './parseListJson';
+import { parseListJson, parseTotalPages } from './parseListJson';
 import { parseDetailPage } from './parseDetailPage';
 import { isViewErrorPage } from './isViewErrorPage';
-import type { AnnouncementDetail } from '@/types/announcement';
+import { checkDetailInvariants } from './parserInvariants';
+import type {
+  AnnouncementDetail,
+  AnnouncementListItem,
+} from '@/types/announcement';
+
+/** 페이지네이션 폭주 방지 상한 (정상 운영에선 1페이지로 충분). */
+const MAX_LIST_PAGES = 20;
 
 const DEFAULT_LIST_URL =
   'https://soco.seoul.go.kr/youth/pgm/home/yohome/bbsListJson.json';
@@ -79,7 +92,7 @@ export interface CrawlAnnouncementsOptions {
 export interface CrawlAnnouncementsResult {
   /**
    * 이번 회차에 새로 발견한 공고의 완전한 detail 목록.
-   * - 모든 신규 boardId를 view.do로 확인한 결과.
+   * - 목록에 존재하는 신규 boardId를 view.do로 확인하고 불변식을 통과한 결과.
    * - boardId 오름차순 정렬.
    * - 부트스트랩(lastBoardId=0) 호출에서는 항상 빈 배열.
    */
@@ -91,10 +104,16 @@ export interface CrawlAnnouncementsResult {
   latestBoardId: number;
   /**
    * 신규 후보 중 view.do가 633B 에러 페이지로 응답한 boardId.
-   * 운영 관찰용(빈 번호가 얼마나 끼는지 추적).
+   * 운영 관찰용(목록·상세 사이 경쟁 상황 추적).
    * boardId 오름차순 정렬.
    */
   skippedBoardIds: number[];
+  /**
+   * view.do는 정상이었으나 파서 불변식(checkDetailInvariants)을 위반해 저장에서
+   * 제외한 boardId. 사이트 구조 변경이나 예외적 공고 형식 신호 — 운영 관찰용.
+   * boardId 오름차순 정렬.
+   */
+  invalidBoardIds: number[];
 }
 
 export async function crawlNewAnnouncements(
@@ -112,12 +131,12 @@ export async function crawlNewAnnouncements(
     rateLimiter = createRateLimiter({ intervalMs }),
   } = options;
 
-  const fetchJsonWithPolicy = (url: string) =>
+  const fetchListPage = (pageIndex: number) =>
     rateLimiter.acquire().then(() =>
       withRetry(
         () =>
-          fetcher(url, {
-            body: listBody,
+          fetcher(listUrl, {
+            body: { ...listBody, pageIndex: String(pageIndex) },
             headers: { Referer: DEFAULT_REFERER },
           }),
         retryOptions,
@@ -134,20 +153,20 @@ export async function crawlNewAnnouncements(
         ),
       );
 
-  // 1) JSON API 1회 호출 → latestBoardId 산출.
-  //    JSON 응답은 신규 boardId 발견과 latest 추적 용도만 담당한다(옵션 B).
-  const jsonText = await fetchJsonWithPolicy(listUrl);
-  const items = parseListJson(jsonText);
+  // 1) 목록 1페이지 호출 → latestBoardId 산출.
+  const firstText = await fetchListPage(1);
+  const firstItems = parseListJson(firstText);
 
-  if (items.length === 0) {
+  if (firstItems.length === 0) {
     return {
       newDetails: [],
       latestBoardId: lastBoardId,
       skippedBoardIds: [],
+      invalidBoardIds: [],
     };
   }
 
-  const latestBoardId = items.reduce(
+  const latestBoardId = firstItems.reduce(
     (max, item) => (item.boardId > max ? item.boardId : max),
     -Infinity,
   );
@@ -160,22 +179,28 @@ export async function crawlNewAnnouncements(
       newDetails: [],
       latestBoardId,
       skippedBoardIds: [],
+      invalidBoardIds: [],
     };
   }
 
-  // 3) 신규 boardId 집합 = lastBoardId+1 ~ latestBoardId 전체.
-  //    JSON에 있든(신규) 없든(gap) 모두 view.do로 detail을 확보한다.
-  //    오름차순이 곧 자연스러운 호출 순서.
-  const newBoardIds: number[] = [];
-  for (let id = lastBoardId + 1; id <= latestBoardId; id++) {
-    newBoardIds.push(id);
-  }
+  // 3) 신규 후보 = 목록에 존재하고 boardId > lastBoardId인 항목 (ADR 007).
+  //    숫자 gap은 채우지 않는다 — 전역 시퀀스라 타 게시판 공고가 섞이기 때문.
+  //    1페이지 최소 boardId가 아직 lastBoardId보다 크면 신규가 페이지를 넘쳤을 수
+  //    있으므로, 다음 페이지가 있는 한 추가로 조회해 누락을 보전한다.
+  const newBoardIds = await collectNewBoardIds({
+    lastBoardId,
+    firstText,
+    firstItems,
+    fetchListPage,
+  });
 
-  // 4) 각 boardId를 view.do로 호출.
-  //    - 633B 에러 페이지 → 비존재 → skippedBoardIds.
-  //    - 정상 → parseDetailPage → newDetails.
+  // 4) 각 신규 boardId를 view.do로 호출.
+  //    - 633B 에러 페이지 → skippedBoardIds.
+  //    - 정상이나 불변식 위반 → invalidBoardIds (저장 제외, 격리).
+  //    - 정상 + 불변식 통과 → newDetails.
   const newDetails: AnnouncementDetail[] = [];
   const skippedBoardIds: number[] = [];
+  const invalidBoardIds: number[] = [];
 
   for (const boardId of newBoardIds) {
     const html = await fetchViewWithPolicy(buildViewUrl(boardId));
@@ -183,12 +208,77 @@ export async function crawlNewAnnouncements(
       skippedBoardIds.push(boardId);
       continue;
     }
-    newDetails.push(parseDetailPage(html, boardId));
+    const detail = parseDetailPage(html, boardId);
+    const violations = checkDetailInvariants(detail);
+    if (violations.length > 0) {
+      console.warn(
+        `[crawl] boardId ${boardId} 불변식 위반 → 저장 제외:`,
+        violations.map((v) => v.code).join(', '),
+      );
+      invalidBoardIds.push(boardId);
+      continue;
+    }
+    newDetails.push(detail);
   }
 
   return {
     newDetails,
     latestBoardId,
     skippedBoardIds,
+    invalidBoardIds,
   };
+}
+
+/**
+ * 목록을 페이지네이션하며 boardId > lastBoardId인 신규 항목의 boardId를
+ * 오름차순·중복 제거해 모은다.
+ *
+ * 1페이지는 이미 받아둔 것을 재사용한다. 다음 페이지로 넘어가는 조건은:
+ * - 현재 페이지 최소 boardId가 아직 lastBoardId보다 큼(경계를 못 넘음), AND
+ * - pagingInfo.totPage 기준 더 볼 페이지가 남음.
+ * totPage가 없으면(키 소실·단일 페이지) 추가 조회하지 않는다.
+ */
+async function collectNewBoardIds(params: {
+  lastBoardId: number;
+  firstText: string;
+  firstItems: AnnouncementListItem[];
+  fetchListPage: (pageIndex: number) => Promise<string>;
+}): Promise<number[]> {
+  const { lastBoardId, firstText, firstItems, fetchListPage } = params;
+
+  const collected = new Set<number>();
+  const addNew = (items: AnnouncementListItem[]) => {
+    for (const item of items) {
+      if (item.boardId > lastBoardId) collected.add(item.boardId);
+    }
+  };
+  const minBoardId = (items: AnnouncementListItem[]) =>
+    items.reduce(
+      (min, item) => (item.boardId < min ? item.boardId : min),
+      Infinity,
+    );
+
+  addNew(firstItems);
+  let pageItems = firstItems;
+  let pageText = firstText;
+  let page = 1;
+
+  while (minBoardId(pageItems) > lastBoardId) {
+    const totPage = parseTotalPages(pageText);
+    if (totPage === null || page >= totPage || page >= MAX_LIST_PAGES) {
+      if (page >= MAX_LIST_PAGES) {
+        console.warn(
+          `[crawl] 페이지네이션 상한(${MAX_LIST_PAGES}) 도달 — 더 오래된 신규가 누락될 수 있음`,
+        );
+      }
+      break;
+    }
+    page += 1;
+    pageText = await fetchListPage(page);
+    pageItems = parseListJson(pageText);
+    if (pageItems.length === 0) break;
+    addNew(pageItems);
+  }
+
+  return [...collected].sort((a, b) => a - b);
 }

--- a/src/lib/crawler/parseListJson.ts
+++ b/src/lib/crawler/parseListJson.ts
@@ -22,7 +22,12 @@ import type {
 const KST_OFFSET_MS = 9 * 60 * 60 * 1000;
 
 interface BbsListJsonResponse {
+  pagingInfo?: BbsPagingInfo | null;
   resultList?: BbsListJsonItem[] | null;
+}
+
+interface BbsPagingInfo {
+  totPage?: number | null;
 }
 
 interface BbsListJsonItem {
@@ -57,6 +62,34 @@ export function parseListJson(jsonText: string): AnnouncementListItem[] {
 
   const list = parsed.resultList ?? [];
   return list.map((item, index) => toListItem(item, index));
+}
+
+/**
+ * 같은 JSON 응답의 `pagingInfo.totPage`(총 페이지 수)를 추출한다.
+ *
+ * 목록 기반 크롤(ADR 007)에서 폴링 사이 1페이지를 넘겨 밀려난 신규를 보전하려면
+ * "다음 페이지가 있는가"를 알아야 한다. 양의 정수가 아니면(키 소실·구조 변경 포함)
+ * null을 반환해 호출자가 "추가 페이지 없음"으로 안전하게 처리하게 한다.
+ */
+export function parseTotalPages(jsonText: string): number | null {
+  let parsed: BbsListJsonResponse;
+  try {
+    parsed = JSON.parse(jsonText) as BbsListJsonResponse;
+  } catch (err) {
+    throw new ParseListJsonError(
+      `Invalid JSON: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+
+  const totPage = parsed.pagingInfo?.totPage;
+  if (
+    typeof totPage !== 'number' ||
+    !Number.isInteger(totPage) ||
+    totPage < 1
+  ) {
+    return null;
+  }
+  return totPage;
 }
 
 function toListItem(


### PR DESCRIPTION
## Summary

운영 크론이 2026-06-16부터 연속 500으로 동결되고 청량리역 퀸즈W(6564)가 누락된 버그를 수정합니다. ADR 007 구현. Closes #42.

## 주요 변경 사항

### 1. gap-fill 폐기 → 목록 기반 크롤 (`announcementService.ts`)

- boardId가 게시판 전역 시퀀스임을 반영해, `lastBoardId+1~latestBoardId` 숫자 gap 열거를 제거.
- 신규 후보 = **BMSR00015 목록에 실제 존재하고 `boardId > lastBoardId`인 항목**만. 타 게시판(BMSR00013 공지 등) 공고가 섞이지 않음(구조적 차단).
- 폴링 사이 1페이지를 넘쳐 밀려난 신규는 `pagingInfo.totPage` 기준 **페이지네이션**으로 보전(기존 gap-fill의 "누락 방지" 목적 계승). 상한 `MAX_LIST_PAGES=20`.

### 2. 저장 전 불변식 게이트 + row별 격리

- 각 detail에 `checkDetailInvariants` 적용. 위반 row는 `invalidBoardIds`로 격리(저장 제외)하고 경고 로깅.
- 단일 불량 row가 배치 upsert 전체를 실패시켜 `last_board_id` 전진을 막던 **동결 메커니즘을 차단**. `latestBoardId`는 위반이 있어도 전진.

### 3. 부수 변경

- `parseListJson.ts`: `parseTotalPages()` 추가(pagingInfo.totPage 추출).
- `route.ts`: 응답에 `invalidBoardIds` 추가, 위반 시 경고 로깅.

## 테스트

- 목록 외 boardId(타 게시판/gap) 미크롤 검증.
- 불변식 위반 detail 격리 + `latestBoardId` 전진 검증.
- `totPage` 기반 페이지네이션(2페이지) 시나리오.
- 전체 86 tests pass, tsc·eslint clean.

## 참고 사항

- 관련: #42 (조사·재현), ADR 007 (#43, 설계 PR — 이 PR과 함께 검토).
- 데이터 오염은 실데이터엔 없음(동결이 먼저 막음). 별도 DB 정리 불필요.
- ⚠️ 머지·배포 후에도 `crawl_state.last_board_id=6562`라 다음 크론이 6564(퀸즈W)부터 정상 수집합니다(6563은 목록에 없어 자동 제외). 즉시 복구를 위한 수동 개입은 불필요.