### PR TITLE
feat: 웹 푸시 Service Worker 등록 + 구독 훅 (#39 Step 9-a)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,6 +9,13 @@ SUPABASE_SERVICE_ROLE_KEY=
 # Register the same value in Vercel env and GitHub repo secrets; never commit
 CRON_SECRET=
 
+# Web Push (VAPID) public key
+# Generate a VAPID key pair (e.g. `npx web-push generate-vapid-keys`).
+# The PUBLIC key is exposed to the client (NEXT_PUBLIC_ prefix) and passed to
+# PushManager.subscribe as applicationServerKey. The matching PRIVATE key is
+# server-side only and is added when push sending is wired up (Step 9-c).
+NEXT_PUBLIC_VAPID_PUBLIC_KEY=
+
 # Live canary boardId (optional, ADR 006)
 # A stable, never-deleted announcement boardId used to verify the detail parser
 # against the live site every crawl. If unset, only list invariants are checked.

--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,7 @@ yarn-error.log*
 /test-results/
 /playwright-report/
 /blob-report/
+/.playwright-mcp/
 
 # vercel
 .vercel

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,0 +1,57 @@
+/**
+ * 청안 웹 푸시 Service Worker
+ *
+ * - push 이벤트: 서버가 보낸 페이로드(JSON)를 받아 알림으로 표시한다.
+ * - notificationclick 이벤트: 알림을 클릭하면 해당 공고(또는 기본 경로)로 이동한다.
+ *
+ * 이 파일은 번들러를 거치지 않고 정적 자산으로 그대로 서빙되므로
+ * import/모듈 문법 없이 순수 self 스코프 API만 사용한다.
+ */
+
+self.addEventListener('push', (event) => {
+  if (!event.data) return;
+
+  let payload;
+  try {
+    payload = event.data.json();
+  } catch {
+    payload = { title: '청안 알림', body: event.data.text() };
+  }
+
+  const {
+    title = '청안 — 새 공고',
+    body = '',
+    url = '/',
+    tag,
+  } = payload ?? {};
+
+  event.waitUntil(
+    self.registration.showNotification(title, {
+      body,
+      tag,
+      data: { url },
+    }),
+  );
+});
+
+self.addEventListener('notificationclick', (event) => {
+  event.notification.close();
+
+  const targetUrl = (event.notification.data && event.notification.data.url) || '/';
+
+  event.waitUntil(
+    self.clients
+      .matchAll({ type: 'window', includeUncontrolled: true })
+      .then((clientList) => {
+        for (const client of clientList) {
+          if (client.url === targetUrl && 'focus' in client) {
+            return client.focus();
+          }
+        }
+        if (self.clients.openWindow) {
+          return self.clients.openWindow(targetUrl);
+        }
+        return undefined;
+      }),
+  );
+});

--- a/public/sw.js
+++ b/public/sw.js
@@ -18,12 +18,7 @@ self.addEventListener('push', (event) => {
     payload = { title: '청안 알림', body: event.data.text() };
   }
 
-  const {
-    title = '청안 — 새 공고',
-    body = '',
-    url = '/',
-    tag,
-  } = payload ?? {};
+  const { title = '청안 — 새 공고', body = '', url = '/', tag } = payload ?? {};
 
   event.waitUntil(
     self.registration.showNotification(title, {
@@ -37,7 +32,8 @@ self.addEventListener('push', (event) => {
 self.addEventListener('notificationclick', (event) => {
   event.notification.close();
 
-  const targetUrl = (event.notification.data && event.notification.data.url) || '/';
+  const targetUrl =
+    (event.notification.data && event.notification.data.url) || '/';
 
   event.waitUntil(
     self.clients

--- a/src/app/subscribe/page.tsx
+++ b/src/app/subscribe/page.tsx
@@ -1,0 +1,16 @@
+import { PushSubscribeButton } from '@/components/push/PushSubscribeButton';
+
+/**
+ * 알림 구독 페이지 (임시 검증 단계, Step 9-a).
+ *
+ * 현재는 subscribe 흐름 검증용 최소 UI만 둔다.
+ * 실제 디자인은 Sprint 2 화면이 모두 잡힌 뒤 v0/Lovable 등으로 일괄 작업한다.
+ */
+export default function SubscribePage() {
+  return (
+    <main className="mx-auto max-w-md p-8">
+      <h1 className="mb-4 text-xl font-bold">알림 구독 (임시)</h1>
+      <PushSubscribeButton />
+    </main>
+  );
+}

--- a/src/components/push/PushSubscribeButton.tsx
+++ b/src/components/push/PushSubscribeButton.tsx
@@ -1,0 +1,53 @@
+'use client';
+
+import { usePushSubscription } from '@/hooks/usePushSubscription';
+
+/**
+ * 임시 검증용 구독 버튼 (Step 9-a).
+ *
+ * 9-a의 subscribe 흐름(SW 등록 → 알림 권한 → PushManager.subscribe)이
+ * 실제 브라우저에서 동작하는지 눈으로 확인하기 위한 최소 UI다.
+ * 본 디자인은 Sprint 2의 화면(구독/목록/상세)이 모두 잡힌 뒤 일괄 작업한다.
+ */
+export function PushSubscribeButton() {
+  const {
+    isSupported,
+    permission,
+    subscription,
+    isSubscribing,
+    error,
+    subscribe,
+  } = usePushSubscription();
+
+  return (
+    <div className="flex flex-col gap-3">
+      <button
+        type="button"
+        onClick={() => void subscribe()}
+        disabled={!isSupported || isSubscribing}
+        className="w-fit rounded bg-blue-600 px-4 py-2 text-white disabled:opacity-50"
+      >
+        {isSubscribing ? '구독 처리 중…' : '알림 구독'}
+      </button>
+
+      <dl className="text-sm">
+        <div>
+          <dt className="inline font-medium">지원: </dt>
+          <dd className="inline">{isSupported ? '예' : '아니오'}</dd>
+        </div>
+        <div>
+          <dt className="inline font-medium">권한: </dt>
+          <dd className="inline">{permission ?? '-'}</dd>
+        </div>
+      </dl>
+
+      {error && <p className="text-sm text-red-600">오류: {error.message}</p>}
+
+      {subscription && (
+        <p className="text-sm break-all text-green-700">
+          구독 생성됨 — endpoint: {subscription.endpoint}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/src/hooks/usePushSubscription.ts
+++ b/src/hooks/usePushSubscription.ts
@@ -1,0 +1,132 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+
+import { urlBase64ToUint8Array } from '@/lib/push/urlBase64ToUint8Array';
+
+const SERVICE_WORKER_URL = '/sw.js';
+
+/**
+ * 현재 브라우저가 웹 푸시에 필요한 API를 모두 지원하는지 확인한다.
+ * SSR 환경(window 부재)에서도 안전하게 false를 반환한다.
+ */
+function detectSupport(): boolean {
+  return (
+    typeof window !== 'undefined' &&
+    'serviceWorker' in navigator &&
+    'PushManager' in window &&
+    'Notification' in window
+  );
+}
+
+export interface UsePushSubscriptionResult {
+  /** 브라우저가 웹 푸시를 지원하는지 여부 */
+  isSupported: boolean;
+  /** 현재 알림 권한 상태. 미지원/SSR 시 null */
+  permission: NotificationPermission | null;
+  /** 활성 푸시 구독. 없으면 null */
+  subscription: PushSubscription | null;
+  /** subscribe() 진행 중 여부 */
+  isSubscribing: boolean;
+  /** 마지막 subscribe() 실패 원인. 성공 시 null */
+  error: Error | null;
+  /**
+   * Service Worker 등록 → 알림 권한 요청 → 푸시 구독을 수행하고
+   * 생성된 PushSubscription을 반환한다. 실패 시 null.
+   * (구독을 서버에 저장하는 것은 별도 단계의 책임이다.)
+   */
+  subscribe: () => Promise<PushSubscription | null>;
+}
+
+/**
+ * 웹 푸시 구독 생성을 담당하는 클라이언트 훅.
+ *
+ * 마운트 시 지원 여부·권한·기존 구독을 복원하고,
+ * subscribe()로 신규 구독을 생성한다. 서버 저장(persist)은
+ * 호출 측 또는 후속 단계(9-b)에서 반환된 subscription으로 처리한다.
+ */
+export function usePushSubscription(): UsePushSubscriptionResult {
+  const [isSupported, setIsSupported] = useState(false);
+  const [permission, setPermission] = useState<NotificationPermission | null>(
+    null,
+  );
+  const [subscription, setSubscription] = useState<PushSubscription | null>(
+    null,
+  );
+  const [isSubscribing, setIsSubscribing] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  useEffect(() => {
+    const supported = detectSupport();
+    setIsSupported(supported);
+    if (!supported) return;
+
+    setPermission(Notification.permission);
+
+    // 이미 활성 구독이 있으면 복원한다. 실패는 치명적이지 않다.
+    navigator.serviceWorker.ready
+      .then((registration) => registration.pushManager.getSubscription())
+      .then((existing) => {
+        if (existing) setSubscription(existing);
+      })
+      .catch(() => {
+        // 복원 실패 시 subscribe()로 재시도 가능하므로 무시한다.
+      });
+  }, []);
+
+  const subscribe = useCallback(async (): Promise<PushSubscription | null> => {
+    if (!detectSupport()) {
+      setError(new Error('이 브라우저는 웹 푸시를 지원하지 않습니다.'));
+      return null;
+    }
+
+    const vapidPublicKey = process.env.NEXT_PUBLIC_VAPID_PUBLIC_KEY;
+    if (!vapidPublicKey) {
+      setError(
+        new Error('NEXT_PUBLIC_VAPID_PUBLIC_KEY가 설정되지 않았습니다.'),
+      );
+      return null;
+    }
+
+    setIsSubscribing(true);
+    setError(null);
+
+    try {
+      const registration =
+        await navigator.serviceWorker.register(SERVICE_WORKER_URL);
+      await navigator.serviceWorker.ready;
+
+      const result = await Notification.requestPermission();
+      setPermission(result);
+      if (result !== 'granted') {
+        throw new Error('알림 권한이 거부되었습니다.');
+      }
+
+      const existing = await registration.pushManager.getSubscription();
+      const next =
+        existing ??
+        (await registration.pushManager.subscribe({
+          userVisibleOnly: true,
+          applicationServerKey: urlBase64ToUint8Array(vapidPublicKey),
+        }));
+
+      setSubscription(next);
+      return next;
+    } catch (err) {
+      const normalized = err instanceof Error ? err : new Error(String(err));
+      setError(normalized);
+      return null;
+    } finally {
+      setIsSubscribing(false);
+    }
+  }, []);
+
+  return {
+    isSupported,
+    permission,
+    subscription,
+    isSubscribing,
+    error,
+    subscribe,
+  };
+}

--- a/src/lib/push/urlBase64ToUint8Array.test.ts
+++ b/src/lib/push/urlBase64ToUint8Array.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest';
+
+import { urlBase64ToUint8Array } from './urlBase64ToUint8Array';
+
+describe('urlBase64ToUint8Array', () => {
+  it('패딩이 필요 없는 표준 문자열을 바이트 배열로 디코드한다', () => {
+    // "AQID" → 0x01 0x02 0x03
+    const result = urlBase64ToUint8Array('AQID');
+    expect(Array.from(result)).toEqual([1, 2, 3]);
+  });
+
+  it('길이가 4의 배수가 아니면 패딩을 복구해 디코드한다', () => {
+    // "AQ"(길이 2) → "AQ==" → 0x01
+    const result = urlBase64ToUint8Array('AQ');
+    expect(Array.from(result)).toEqual([1]);
+  });
+
+  it('base64url 치환 문자(-, _)를 표준 base64로 복원한다', () => {
+    // "__w" → "//w=" → 0xFF 0xFC (치환 + 패딩 동시 검증, 마지막 2비트는 버려짐)
+    const result = urlBase64ToUint8Array('__w');
+    expect(Array.from(result)).toEqual([255, 252]);
+  });
+
+  it('Uint8Array 인스턴스를 반환한다', () => {
+    expect(urlBase64ToUint8Array('AQID')).toBeInstanceOf(Uint8Array);
+  });
+
+  it('빈 문자열은 빈 배열을 반환한다', () => {
+    expect(urlBase64ToUint8Array('').length).toBe(0);
+  });
+});

--- a/src/lib/push/urlBase64ToUint8Array.ts
+++ b/src/lib/push/urlBase64ToUint8Array.ts
@@ -1,0 +1,20 @@
+/**
+ * VAPID public key (base64url 문자열)를 PushManager.subscribe의
+ * applicationServerKey 파라미터에 넣을 수 있는 Uint8Array로 변환한다.
+ *
+ * web-push가 생성하는 VAPID 공개키는 base64url 형식이지만
+ * atob는 표준 base64만 받으므로 패딩 복구 + 문자 치환 후 디코드한다.
+ */
+export function urlBase64ToUint8Array(base64UrlString: string): Uint8Array {
+  const padding = '='.repeat((4 - (base64UrlString.length % 4)) % 4);
+  const base64 = (base64UrlString + padding)
+    .replace(/-/g, '+')
+    .replace(/_/g, '/');
+
+  const rawData = atob(base64);
+  const output = new Uint8Array(rawData.length);
+  for (let i = 0; i < rawData.length; i++) {
+    output[i] = rawData.charCodeAt(i);
+  }
+  return output;
+}

--- a/src/lib/push/urlBase64ToUint8Array.ts
+++ b/src/lib/push/urlBase64ToUint8Array.ts
@@ -5,7 +5,9 @@
  * web-push가 생성하는 VAPID 공개키는 base64url 형식이지만
  * atob는 표준 base64만 받으므로 패딩 복구 + 문자 치환 후 디코드한다.
  */
-export function urlBase64ToUint8Array(base64UrlString: string): Uint8Array {
+export function urlBase64ToUint8Array(
+  base64UrlString: string,
+): Uint8Array<ArrayBuffer> {
   const padding = '='.repeat((4 - (base64UrlString.length % 4)) % 4);
   const base64 = (base64UrlString + padding)
     .replace(/-/g, '+')


### PR DESCRIPTION
## Summary

Step 9-a: 웹 푸시 구독의 클라이언트 경로를 완성한다. VAPID 공개키 변환 유틸에 이어 Service Worker 등록, 구독 훅, 그리고 흐름을 실제 브라우저에서 확인하기 위한 임시 검증 UI를 추가했다. 서버 저장(`push_subscriptions`)은 9-b, 발송(`web-push`)은 9-c 범위다.

## 주요 변경 사항

### 1. Service Worker

- `public/sw.js`: `push` 이벤트 → 알림 표시, `notificationclick` → 열린 탭 포커스 또는 새 창으로 공고 이동. 번들러를 거치지 않는 정적 자산이라 순수 self 스코프 API만 사용.

### 2. 구독 훅

- `src/hooks/usePushSubscription.ts`: SW 등록 → 알림 권한 요청 → `PushManager.subscribe`. 기존 구독 복원, 미지원/SSR 가드, 에러/진행 상태 노출. 생성된 `PushSubscription`을 반환(저장은 호출 측·후속 단계 책임).

### 3. VAPID 유틸 보강

- `src/lib/push/urlBase64ToUint8Array.test.ts`: 패딩 복구·치환 문자·인스턴스·빈 문자열 테스트 백필(5케이스).
- `urlBase64ToUint8Array` 반환 타입을 `Uint8Array<ArrayBuffer>`로 타이트닝 — TS 5.7의 `ArrayBufferLike` 엄격화로 `applicationServerKey`(BufferSource)에 직접 할당 가능하게.

### 4. 임시 검증 UI

- `src/components/push/PushSubscribeButton.tsx`, `src/app/subscribe/page.tsx`: subscribe 흐름 확인용 최소 UI. **본 디자인은 Sprint 2 화면(구독/목록/상세)이 모두 잡힌 뒤 일괄 작업하므로 임시 버전이다.**

### 5. 기타

- `.env.example`: `NEXT_PUBLIC_VAPID_PUBLIC_KEY` 추가(private 키는 9-c).
- `.gitignore`: Playwright MCP 산출물(`.playwright-mcp/`) 제외.

## 참고 사항

- 관련 이슈: #39 (Step 9-a 체크박스)
- **검증**: 실제 Chrome에서 `/subscribe` → "알림 구독" → 권한 허용 → 푸시 endpoint 생성까지 end-to-end 확인. `pnpm test`(91) · `typecheck` · `lint` 그린.
- **학습 문서**: Service Worker / Push API는 새 기술 개념이나, 발송까지 포함한 전체 패턴이 완결되는 9-c 시점에 `docs/learning/step9-web-push.md` 1건으로 일괄 작성 예정.
- 다음: 9-b(구독 저장 API + `push_subscriptions` 스키마).
