### PR TITLE
feat: Supabase Auth SSR 기반 (#50, Step 50-a)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,12 @@
 SUPABASE_URL=
 SUPABASE_SERVICE_ROLE_KEY=
 
+# Supabase Auth (public) — browser/server client for social login (ADR 009)
+# Get from: Supabase Project Settings → API. The anon key is safe to expose to
+# the client (NEXT_PUBLIC_ prefix); access is controlled by RLS.
+NEXT_PUBLIC_SUPABASE_URL=
+NEXT_PUBLIC_SUPABASE_ANON_KEY=
+
 # Cron trigger shared secret
 # Used by /api/cron/crawl to authorize scheduled invocations (GitHub Actions / curl)
 # Register the same value in Vercel env and GitHub repo secrets; never commit

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -11,7 +11,7 @@
 
 Sprint 2 1번 작업(웹 푸시 파이프라인, #39)을 Step(9-a~d)으로 쪼개 진행 중. **9-a 완료·머지**(PR #47): VAPID 유틸 + Service Worker 등록 + 구독 훅 + 임시 검증 UI까지 클라이언트 구독 경로 완성, 실제 Chrome에서 구독→endpoint 생성 end-to-end 검증.
 
-**방향 전환(2026-06-25)**: 9-b 설계 중 서비스를 **로그인 사용자 기준**으로 운영하기로 결정 — 구독·발송·필터를 처음부터 `user_id`로 묶는다. 익명으로 먼저 만들면 나중에 user 연결 마이그레이션 + 고아 구독 정리로 두 번 일하므로, 순서를 바꿔 **소셜 로그인을 9-b 앞에 신규 편입**한다(근거: **ADR 009**). 이에 따라 ADR 008은 익명 → user 연결 모델로 **재작성**했고(`user_id` FK + RLS, endpoint UNIQUE·`410 Gone`은 유지), PROJECT_PLAN Sprint 2에 로그인을 편입했다. 학습 문서(`docs/learning/step9-web-push.md`)는 발송까지 완결되는 9-c 시점에 일괄 작성 예정.
+**방향 전환(2026-06-25)**: 9-b 설계 중 서비스를 **로그인 사용자 기준**으로 운영하기로 결정 — 구독·발송·필터를 처음부터 `user_id`로 묶는다. 익명으로 먼저 만들면 나중에 user 연결 마이그레이션 + 고아 구독 정리로 두 번 일하므로, 순서를 바꿔 **소셜 로그인을 9-b 앞에 신규 편입**한다(근거: **ADR 009**). 이에 따라 ADR 008은 익명 → user 연결 모델로 **재작성**했고(`user_id` FK + RLS, endpoint UNIQUE·`410 Gone`은 유지), PROJECT_PLAN Sprint 2에 로그인을 편입했다(#50). 소셜 로그인은 50-a(SSR 기반)·50-b(로그인 UI + 게이팅)로 분할했고 **50-a 완료**(PR #52). 학습 문서(`docs/learning/step9-web-push.md`)는 발송까지 완결되는 9-c 시점에, `@supabase/ssr` SSR 패턴 학습 문서는 50 마무리 시점에 작성 예정.
 
 ### ✅ 해소됨 — 크롤 파이프라인 동결 (Issue #42, 2026-06-18)
 
@@ -19,20 +19,21 @@ Sprint 2 1번 작업(웹 푸시 파이프라인, #39)을 Step(9-a~d)으로 쪼�
 
 ### 완료된 Step
 
-| Step           | 내용                                                                                                                  | 근거·산출물                                                                                         |
-| -------------- | --------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------- |
-| Step 2         | Next.js 초기화, Prettier/husky/lint-staged, Vitest/Playwright                                                         | `learning/step2-essentials`                                                                         |
-| Step 3         | Vercel 연동 + GitHub Actions CI (lint·tsc·test)                                                                       | `learning/step3-ci-setup`                                                                           |
-| Step 4         | 크롤 파서 + DB 스키마 + 타입                                                                                          | `learning/step4-{cheerio,vitest-basics,db-basics}` (※ `parseMainPage`·`checkBoardId`는 Step 6 폐기) |
-| Step 5-a~d     | fetch+retry / rateLimit / `announcementService` 합성 / MSW 통합테스트                                                 | `learning/step5-{fetch-html,retry,rate-limit,msw-testing}`                                          |
-| Step 6         | 데이터 소스 재설계: JSON 목록(주) + view.do 하이브리드 (epic #19)                                                     | ADR 002/003; PR #20~23·#25                                                                          |
-| Step 6 정리    | `checkBoardId` 모듈 실제 삭제 + 이슈 본문 정리                                                                        | PR #27                                                                                              |
-| Step 7         | Supabase 저장 통합: admin 클라 + `announcements` UPSERT + `crawl_state` 리포                                          | `learning/step7-*`; PR #29·#30                                                                      |
-| Step 8         | 크롤 스케줄러: `/api/cron/crawl` + `crawl.yml` (1h cron + dispatch), `CRON_SECRET` 인증                               | ADR 004; `learning/step8-gha-cron-vercel-trigger`; PR #35                                           |
-| Step 8 픽스    | 부트스트랩 catch-up 루프 픽스 — 시드 0이면 latestBoardId만 저장 (#36)                                                 | ADR 005; `troubleshooting/2026-06-09-cron-bootstrap-catch-up`                                       |
-| 크롤 동결 픽스 | 동결 해소 (#42): gap-fill 폐기 → 목록 기반 크롤, 페이지네이션 보전, row별 격리. 프로덕션 500→200 검증                 | ADR 007; PR #43·#45                                                                                 |
-| Step 9-a       | 웹 푸시 구독 클라 경로 (#39): VAPID 유틸 + SW 등록 + `usePushSubscription` 훅 + 임시 `/subscribe` UI. Chrome E2E 검증 | PR #47 (서버 저장 9-b·발송 9-c)                                                                     |
-| 운영·회고      | Sprint 1 운영 검증 (GHA dispatch 2회 success, `last_board_id` 6561 갱신) + Sprint 1 회고                              | `retrospectives/sprint-1`                                                                           |
+| Step           | 내용                                                                                                                                     | 근거·산출물                                                                                         |
+| -------------- | ---------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------- |
+| Step 2         | Next.js 초기화, Prettier/husky/lint-staged, Vitest/Playwright                                                                            | `learning/step2-essentials`                                                                         |
+| Step 3         | Vercel 연동 + GitHub Actions CI (lint·tsc·test)                                                                                          | `learning/step3-ci-setup`                                                                           |
+| Step 4         | 크롤 파서 + DB 스키마 + 타입                                                                                                             | `learning/step4-{cheerio,vitest-basics,db-basics}` (※ `parseMainPage`·`checkBoardId`는 Step 6 폐기) |
+| Step 5-a~d     | fetch+retry / rateLimit / `announcementService` 합성 / MSW 통합테스트                                                                    | `learning/step5-{fetch-html,retry,rate-limit,msw-testing}`                                          |
+| Step 6         | 데이터 소스 재설계: JSON 목록(주) + view.do 하이브리드 (epic #19)                                                                        | ADR 002/003; PR #20~23·#25                                                                          |
+| Step 6 정리    | `checkBoardId` 모듈 실제 삭제 + 이슈 본문 정리                                                                                           | PR #27                                                                                              |
+| Step 7         | Supabase 저장 통합: admin 클라 + `announcements` UPSERT + `crawl_state` 리포                                                             | `learning/step7-*`; PR #29·#30                                                                      |
+| Step 8         | 크롤 스케줄러: `/api/cron/crawl` + `crawl.yml` (1h cron + dispatch), `CRON_SECRET` 인증                                                  | ADR 004; `learning/step8-gha-cron-vercel-trigger`; PR #35                                           |
+| Step 8 픽스    | 부트스트랩 catch-up 루프 픽스 — 시드 0이면 latestBoardId만 저장 (#36)                                                                    | ADR 005; `troubleshooting/2026-06-09-cron-bootstrap-catch-up`                                       |
+| 크롤 동결 픽스 | 동결 해소 (#42): gap-fill 폐기 → 목록 기반 크롤, 페이지네이션 보전, row별 격리. 프로덕션 500→200 검증                                    | ADR 007; PR #43·#45                                                                                 |
+| Step 9-a       | 웹 푸시 구독 클라 경로 (#39): VAPID 유틸 + SW 등록 + `usePushSubscription` 훅 + 임시 `/subscribe` UI. Chrome E2E 검증                    | PR #47 (서버 저장 9-b·발송 9-c)                                                                     |
+| Step 50-a      | 소셜 로그인 SSR 기반 (#50): `@supabase/ssr` browser/server 클라 + 세션 미들웨어 + OAuth 콜백 라우트. typecheck/lint/96 tests (정적·단위) | ADR 009; PR #52 (로그인 UI·게이팅 50-b)                                                             |
+| 운영·회고      | Sprint 1 운영 검증 (GHA dispatch 2회 success, `last_board_id` 6561 갱신) + Sprint 1 회고                                                 | `retrospectives/sprint-1`                                                                           |
 
 > ADR 전체: `docs/adr/` — 001 기술스택, 002/003 데이터소스·매핑, 004 스케줄러, 005 부트스트랩, 006 크롤 출력 검증, 007 크롤 범위, 008 구독 저장 모델(user 연결), 009 소셜 로그인.
 
@@ -44,7 +45,8 @@ Sprint 2 1번 작업(웹 푸시 파이프라인, #39)을 Step(9-a~d)으로 쪼�
 
 웹 푸시 파이프라인 (#39) 남은 Step (로그인 편입으로 재배열):
 
-- **소셜 로그인 (진행 중 · #50)**: Supabase Auth + `@supabase/ssr` — browser/server 클라 + `middleware.ts`(세션 갱신) + `/auth/callback`(`exchangeCodeForSession`) + 구글·카카오 로그인/로그아웃 UI. 외부: 구글·카카오 콘솔 OAuth 앱 + Supabase 대시보드 provider 설정(수작업). 범위·근거 **ADR 009**.
+- **소셜 로그인 50-b (다음 · #50)**: 구글·카카오 로그인/로그아웃 UI(`signInWithOAuth({ provider })`) + `/subscribe`·`PushSubscribeButton` 비로그인 게이팅. 50-a(SSR 기반: 클라·미들웨어·콜백)는 **PR #52**로 완료 — 그 위에 얹는다. 범위·근거 **ADR 009**.
+  - **외부 선결(50-b E2E 전제, 사용자 작업)**: Supabase 대시보드 Google·Kakao provider 활성화 + client_id/secret + redirect allow-list / 구글·카카오 콘솔 OAuth 앱 등록 / env `NEXT_PUBLIC_SUPABASE_URL`·`NEXT_PUBLIC_SUPABASE_ANON_KEY` 주입(로컬 + Vercel). 미설정이어도 코드·단위 테스트는 진행 가능.
 - 9-b: 구독 저장 API + DB 스키마 (`push_subscriptions`) — `user_id` FK(NOT NULL) + endpoint UNIQUE + RLS. `POST /api/push/subscribe`는 세션에서 `user_id` 도출(비로그인 401). 모델·근거 **ADR 008**.
 - 9-c: 발송 트리거(크롤 신규 감지와 연결) + `web-push` 통합 + `WHERE user_id`로 사용자 구독 조회 + `410 Gone` 만료 정리
 - 9-d: Playwright E2E (로그인 → 구독 → 신규 공고 → 알림 수신)

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "prepare": "husky"
   },
   "dependencies": {
-    "@supabase/supabase-js": "^2.106.2",
+    "@supabase/ssr": "^0.12.0",
+    "@supabase/supabase-js": "^2.108.2",
     "cheerio": "^1.2.0",
     "clsx": "^2.1.1",
     "next": "16.2.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,9 +8,12 @@ importers:
 
   .:
     dependencies:
+      '@supabase/ssr':
+        specifier: ^0.12.0
+        version: 0.12.0(@supabase/supabase-js@2.108.2)
       '@supabase/supabase-js':
-        specifier: ^2.106.2
-        version: 2.106.2
+        specifier: ^2.108.2
+        version: 2.108.2
       cheerio:
         specifier: ^1.2.0
         version: 1.2.0
@@ -699,31 +702,36 @@ packages:
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
-  '@supabase/auth-js@2.106.2':
-    resolution: {integrity: sha512-VcAjUErkHkhC5Jaf+g/G1qbkQrFh8edaCdHa7pxJmHUjkWKjT7UnYCtPA89XV0N0GIYRkEqJZw5V62CtOxTmBQ==}
+  '@supabase/auth-js@2.108.2':
+    resolution: {integrity: sha512-tNaQmBgodDZwgB40mRwVbxFy8IDYwjdpcZ0BYrWiwlULCSQoJj4QoG4zgJT7QRPXcqipefNOzvO/qAu4dF98ag==}
     engines: {node: '>=20.0.0'}
 
-  '@supabase/functions-js@2.106.2':
-    resolution: {integrity: sha512-oRnr0QrL8H+zTO1YyQ1QjiHZU/957jvubbxSJTUm2XLAgzoGGV9Tahfyd+uvLsBLRVmXLtpU3oyCjdQIvkGMOA==}
+  '@supabase/functions-js@2.108.2':
+    resolution: {integrity: sha512-RNUX8EiBy3iLwAX19jtRzLyePnl11/fHcgwDHLnpKcDSXt/5qBnh3LUwAtIjT21Q66QsmNUR2esrHziLCpNubw==}
     engines: {node: '>=20.0.0'}
 
   '@supabase/phoenix@0.4.2':
     resolution: {integrity: sha512-YSAGnmDAfuleFCVt3CeurQZAhxRfXWeZIIkwp7NhYzQ1UwW6ePSnzsFAiUm/mbCkfoCf70QQHKW/K6RKh52a4A==}
 
-  '@supabase/postgrest-js@2.106.2':
-    resolution: {integrity: sha512-tDOzyPgp9pIRMR2x6C9+uDSJrnXSzxLtt3d7nC+Lrsy3jnJDHYfdQC/xcRyhJE/TOBJ0heSqRKR3UmejDjZxsw==}
+  '@supabase/postgrest-js@2.108.2':
+    resolution: {integrity: sha512-GQ28/Y8hk3CFmkb3kXH1h/AQx6JIYSQfO0CJMRVBcEKZoNy6C45cXAZ4fcJvRC5Id0cs6xnkUV0+c0rIocigsw==}
     engines: {node: '>=20.0.0'}
 
-  '@supabase/realtime-js@2.106.2':
-    resolution: {integrity: sha512-LdRGT7DNhyZkPjubUv5bSdAZ0jSEX8wTHvx7htj7+K59TOZRvz4TuQK7tL2RWxyIZVeFMRluL04SzWS61rKnUA==}
+  '@supabase/realtime-js@2.108.2':
+    resolution: {integrity: sha512-aAGxCSUemZvQIibnCdvNvgaKib28I4rfrNjKbQ9cG1uBLwUsI7hVpGXgEbypCCDhLjQlDTAiJlu7rgljYUT73g==}
     engines: {node: '>=20.0.0'}
 
-  '@supabase/storage-js@2.106.2':
-    resolution: {integrity: sha512-xgKCSYuev1YarV+iVqr+zlfgSyremnJtn8T0NCT8L4XmMv1CLtESc0Q6kNp8+mKWdX/8ND0nzm7OMKx08kwNAw==}
+  '@supabase/ssr@0.12.0':
+    resolution: {integrity: sha512-d9XV5XzJvzzZbeAIM7fWTCUYxQJZ2Ru6ny3dJHmHGp/LIrJ+o9FpD7N9Rf/UhhWEvHXSoDe8SI32Z2ouOdMjBg==}
+    peerDependencies:
+      '@supabase/supabase-js': ^2.108.0
+
+  '@supabase/storage-js@2.108.2':
+    resolution: {integrity: sha512-TVZPQxXGxY2+A6yTtm77zUHsh70lBhYUEaJL8RQC+BghcX/ygiMG/rmXrNVBce30/WAeNPa8FiG8HbqlGeV05g==}
     engines: {node: '>=20.0.0'}
 
-  '@supabase/supabase-js@2.106.2':
-    resolution: {integrity: sha512-2/RZ/1fmJx/MRSEDG2Xk8+J4JVk5clM9V0uSI6kUTrcS32KA89DtqI5RUOC9r6mzY3WBC9qexLjssIHjbLyVJA==}
+  '@supabase/supabase-js@2.108.2':
+    resolution: {integrity: sha512-hFhnPveb5JQg4a0QYicM0swT253YHMdfeRAl2BKHOlI5VAzuHxUGSr8RbwNLYNPauWOgQMS1H8sz8bvYlgwUfQ==}
     engines: {node: '>=20.0.0'}
 
   '@swc/helpers@0.5.15':
@@ -3437,37 +3445,42 @@ snapshots:
 
   '@standard-schema/spec@1.1.0': {}
 
-  '@supabase/auth-js@2.106.2':
+  '@supabase/auth-js@2.108.2':
     dependencies:
       tslib: 2.8.1
 
-  '@supabase/functions-js@2.106.2':
+  '@supabase/functions-js@2.108.2':
     dependencies:
       tslib: 2.8.1
 
   '@supabase/phoenix@0.4.2': {}
 
-  '@supabase/postgrest-js@2.106.2':
+  '@supabase/postgrest-js@2.108.2':
     dependencies:
       tslib: 2.8.1
 
-  '@supabase/realtime-js@2.106.2':
+  '@supabase/realtime-js@2.108.2':
     dependencies:
       '@supabase/phoenix': 0.4.2
       tslib: 2.8.1
 
-  '@supabase/storage-js@2.106.2':
+  '@supabase/ssr@0.12.0(@supabase/supabase-js@2.108.2)':
+    dependencies:
+      '@supabase/supabase-js': 2.108.2
+      cookie: 1.1.1
+
+  '@supabase/storage-js@2.108.2':
     dependencies:
       iceberg-js: 0.8.1
       tslib: 2.8.1
 
-  '@supabase/supabase-js@2.106.2':
+  '@supabase/supabase-js@2.108.2':
     dependencies:
-      '@supabase/auth-js': 2.106.2
-      '@supabase/functions-js': 2.106.2
-      '@supabase/postgrest-js': 2.106.2
-      '@supabase/realtime-js': 2.106.2
-      '@supabase/storage-js': 2.106.2
+      '@supabase/auth-js': 2.108.2
+      '@supabase/functions-js': 2.108.2
+      '@supabase/postgrest-js': 2.108.2
+      '@supabase/realtime-js': 2.108.2
+      '@supabase/storage-js': 2.108.2
 
   '@swc/helpers@0.5.15':
     dependencies:

--- a/src/app/auth/callback/route.test.ts
+++ b/src/app/auth/callback/route.test.ts
@@ -1,0 +1,83 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/lib/supabase/serverClient', () => ({
+  getSupabaseServerClient: vi.fn(),
+}));
+
+import { getSupabaseServerClient } from '@/lib/supabase/serverClient';
+
+import { GET } from './route';
+
+type MockClient = {
+  auth: { exchangeCodeForSession: ReturnType<typeof vi.fn> };
+};
+
+function mockServerClient(exchangeResult: { error: unknown }): MockClient {
+  const client: MockClient = {
+    auth: { exchangeCodeForSession: vi.fn().mockResolvedValue(exchangeResult) },
+  };
+  vi.mocked(getSupabaseServerClient).mockResolvedValue(
+    client as unknown as Awaited<ReturnType<typeof getSupabaseServerClient>>,
+  );
+  return client;
+}
+
+function callbackRequest(query: string): Request {
+  return new Request(`http://localhost/auth/callback${query}`);
+}
+
+function locationOf(response: Response): string {
+  const location = response.headers.get('location');
+  if (!location) throw new Error('redirect response has no location header');
+  return location;
+}
+
+describe('GET /auth/callback', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('code 누락 시 교환 없이 홈으로 리다이렉트(auth_error)', async () => {
+    const response = await GET(callbackRequest(''));
+
+    expect(locationOf(response)).toBe(
+      'http://localhost/?auth_error=missing_code',
+    );
+    expect(getSupabaseServerClient).not.toHaveBeenCalled();
+  });
+
+  it('code 교환 성공 시 next(기본 홈)로 리다이렉트', async () => {
+    const client = mockServerClient({ error: null });
+
+    const response = await GET(callbackRequest('?code=abc'));
+
+    expect(client.auth.exchangeCodeForSession).toHaveBeenCalledWith('abc');
+    expect(locationOf(response)).toBe('http://localhost/');
+  });
+
+  it('code 교환 성공 + next 지정 시 해당 경로로 리다이렉트', async () => {
+    mockServerClient({ error: null });
+
+    const response = await GET(callbackRequest('?code=abc&next=/subscribe'));
+
+    expect(locationOf(response)).toBe('http://localhost/subscribe');
+  });
+
+  it('외부 경로(//evil.com)는 open redirect 방지로 홈으로', async () => {
+    mockServerClient({ error: null });
+
+    const response = await GET(callbackRequest('?code=abc&next=//evil.com'));
+
+    expect(locationOf(response)).toBe('http://localhost/');
+  });
+
+  it('code 교환 실패 시 홈으로 리다이렉트(auth_error)', async () => {
+    mockServerClient({ error: new Error('invalid code') });
+
+    const response = await GET(callbackRequest('?code=bad'));
+
+    expect(locationOf(response)).toBe(
+      'http://localhost/?auth_error=exchange_failed',
+    );
+  });
+});

--- a/src/app/auth/callback/route.ts
+++ b/src/app/auth/callback/route.ts
@@ -1,0 +1,38 @@
+import { NextResponse } from 'next/server';
+
+import { getSupabaseServerClient } from '@/lib/supabase/serverClient';
+
+/**
+ * OAuth 로그인 콜백. provider 리다이렉트로 받은 authorization code를
+ * 세션으로 교환(`exchangeCodeForSession`)하고 앱으로 되돌린다. (ADR 009)
+ *
+ * 성공: `next`(기본 '/')로 리다이렉트.
+ * 실패(code 누락·교환 실패): 홈으로 리다이렉트하며 `auth_error` 쿼리 부착.
+ */
+export async function GET(request: Request): Promise<Response> {
+  const { searchParams, origin } = new URL(request.url);
+  const code = searchParams.get('code');
+  const next = sanitizeNext(searchParams.get('next'));
+
+  if (!code) {
+    return NextResponse.redirect(`${origin}/?auth_error=missing_code`);
+  }
+
+  const supabase = await getSupabaseServerClient();
+  const { error } = await supabase.auth.exchangeCodeForSession(code);
+
+  if (error) {
+    return NextResponse.redirect(`${origin}/?auth_error=exchange_failed`);
+  }
+
+  return NextResponse.redirect(`${origin}${next}`);
+}
+
+/**
+ * open redirect 방지: 앱 내부 절대경로(`/`로 시작, `//` 제외)만 허용하고
+ * 그 외에는 홈(`/`)으로 돌린다.
+ */
+function sanitizeNext(next: string | null): string {
+  if (!next || !next.startsWith('/') || next.startsWith('//')) return '/';
+  return next;
+}

--- a/src/lib/supabase/browserClient.ts
+++ b/src/lib/supabase/browserClient.ts
@@ -1,0 +1,15 @@
+/**
+ * 브라우저(클라이언트 컴포넌트)용 Supabase 클라이언트.
+ *
+ * 공개 anon 키를 사용하며, 쿠키 기반 세션을 브라우저에서 읽고 쓴다.
+ * 로그인 트리거(`signInWithOAuth`)·로그아웃 등 클라이언트 인증 동작에 쓴다. (ADR 009)
+ */
+
+import { createBrowserClient } from '@supabase/ssr';
+
+import { getSupabasePublicConfig } from './publicConfig';
+
+export function getSupabaseBrowserClient() {
+  const { url, anonKey } = getSupabasePublicConfig();
+  return createBrowserClient(url, anonKey);
+}

--- a/src/lib/supabase/middleware.ts
+++ b/src/lib/supabase/middleware.ts
@@ -1,0 +1,43 @@
+/**
+ * 미들웨어용 세션 갱신 헬퍼.
+ *
+ * 요청 쿠키의 세션을 읽어 `getClaims()`로 검증·갱신하고, 갱신된 토큰을
+ * 요청·응답 쿠키에 반영한다. 서버 컴포넌트는 쿠키를 직접 쓸 수 없으므로
+ * 토큰의 주기적 갱신은 미들웨어가 담당한다. (ADR 009)
+ */
+
+import { createServerClient } from '@supabase/ssr';
+import { NextResponse, type NextRequest } from 'next/server';
+
+import { getSupabasePublicConfig } from './publicConfig';
+
+export async function updateSession(
+  request: NextRequest,
+): Promise<NextResponse> {
+  let supabaseResponse = NextResponse.next({ request });
+
+  const { url, anonKey } = getSupabasePublicConfig();
+
+  const supabase = createServerClient(url, anonKey, {
+    cookies: {
+      getAll() {
+        return request.cookies.getAll();
+      },
+      setAll(cookiesToSet) {
+        cookiesToSet.forEach(({ name, value }) => {
+          request.cookies.set(name, value);
+        });
+        supabaseResponse = NextResponse.next({ request });
+        cookiesToSet.forEach(({ name, value, options }) => {
+          supabaseResponse.cookies.set(name, value, options);
+        });
+      },
+    },
+  });
+
+  // 중요: createServerClient와 getClaims() 사이에 다른 코드를 넣지 말 것.
+  // 세션 갱신 타이밍이 어긋나면 무작위 로그아웃이 발생할 수 있다.
+  await supabase.auth.getClaims();
+
+  return supabaseResponse;
+}

--- a/src/lib/supabase/publicConfig.ts
+++ b/src/lib/supabase/publicConfig.ts
@@ -1,0 +1,36 @@
+/**
+ * 브라우저/SSR Supabase 클라이언트가 공유하는 공개 환경 변수 읽기.
+ *
+ * admin 클라이언트(client.ts)의 service role key와 달리, 이 값들은
+ * 클라이언트 번들에 노출되어도 안전한 공개 키(anon)다. 데이터 접근은
+ * RLS로 제어된다. (ADR 009)
+ *
+ * 환경 변수:
+ * - NEXT_PUBLIC_SUPABASE_URL
+ * - NEXT_PUBLIC_SUPABASE_ANON_KEY
+ */
+
+export interface SupabasePublicConfig {
+  url: string;
+  anonKey: string;
+}
+
+export function getSupabasePublicConfig(): SupabasePublicConfig {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const anonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+
+  if (!url) {
+    throw new Error(
+      'NEXT_PUBLIC_SUPABASE_URL environment variable is not set. ' +
+        'Supabase Auth (browser/server client) requires this variable.',
+    );
+  }
+  if (!anonKey) {
+    throw new Error(
+      'NEXT_PUBLIC_SUPABASE_ANON_KEY environment variable is not set. ' +
+        'Supabase Auth (browser/server client) requires this variable.',
+    );
+  }
+
+  return { url, anonKey };
+}

--- a/src/lib/supabase/serverClient.ts
+++ b/src/lib/supabase/serverClient.ts
@@ -1,0 +1,38 @@
+/**
+ * 서버(서버 컴포넌트 / Route Handler / 서버 액션)용 세션 바인딩 Supabase 클라이언트.
+ *
+ * 요청 쿠키에서 세션을 읽고, 토큰 갱신 시 응답 쿠키에 기록한다.
+ * 세션 토큰의 주기적 갱신은 middleware.ts가 담당한다.
+ * 서버에서 인증 상태를 확인할 때는 `getClaims()`를 쓴다(ADR 009).
+ *
+ * admin 클라이언트(client.ts, service role)와 용도가 다르다 — 이쪽은
+ * 로그인한 사용자 컨텍스트로 동작해 RLS가 소유권을 강제한다.
+ */
+
+import { createServerClient } from '@supabase/ssr';
+import { cookies } from 'next/headers';
+
+import { getSupabasePublicConfig } from './publicConfig';
+
+export async function getSupabaseServerClient() {
+  const cookieStore = await cookies();
+  const { url, anonKey } = getSupabasePublicConfig();
+
+  return createServerClient(url, anonKey, {
+    cookies: {
+      getAll() {
+        return cookieStore.getAll();
+      },
+      setAll(cookiesToSet) {
+        try {
+          cookiesToSet.forEach(({ name, value, options }) => {
+            cookieStore.set(name, value, options);
+          });
+        } catch {
+          // 서버 컴포넌트에서 호출되면 쿠키 쓰기가 막힌다.
+          // 세션 갱신은 미들웨어가 처리하므로 여기서는 무시해도 안전하다.
+        }
+      },
+    },
+  });
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,19 @@
+import { type NextRequest } from 'next/server';
+
+import { updateSession } from '@/lib/supabase/middleware';
+
+/**
+ * 모든 (정적 자산 제외) 요청에서 Supabase 세션 토큰을 갱신한다. (ADR 009)
+ */
+export async function middleware(request: NextRequest): Promise<Response> {
+  return updateSession(request);
+}
+
+export const config = {
+  matcher: [
+    /*
+     * 정적 자산·이미지·Service Worker(`sw.js`)를 제외한 모든 경로에서 동작한다.
+     */
+    '/((?!_next/static|_next/image|favicon.ico|sw.js|manifest.webmanifest|.*\\.(?:svg|png|jpg|jpeg|gif|webp)$).*)',
+  ],
+};


### PR DESCRIPTION
## Summary

소셜 로그인(#50)의 **Step 50-a — Supabase Auth SSR 기반**입니다. `@supabase/ssr`로 브라우저/서버 클라이언트, 세션 갱신 미들웨어, OAuth 콜백 라우트를 깝니다. 로그인/로그아웃 UI와 `/subscribe` 게이팅은 **50-b**에서 이어집니다. (설계·근거: ADR 009)

## 주요 변경 사항

### 1. Supabase 클라이언트 (공개 anon)

- `lib/supabase/publicConfig.ts` — 공개 env(`NEXT_PUBLIC_SUPABASE_URL` / `NEXT_PUBLIC_SUPABASE_ANON_KEY`) 공유 헬퍼 (admin `client.ts`의 service-role과 용도 분리)
- `lib/supabase/browserClient.ts` — `createBrowserClient`
- `lib/supabase/serverClient.ts` — `createServerClient`, `getAll/setAll` 쿠키 인터페이스, 서버는 async `cookies()`

### 2. 세션 미들웨어

- `lib/supabase/middleware.ts` — `updateSession`: `getClaims()`로 토큰 갱신, 요청·응답 쿠키 반영
- `src/middleware.ts` — 엔트리 + matcher (정적 자산·`sw.js` 제외)

### 3. OAuth 콜백

- `app/auth/callback/route.ts` — `exchangeCodeForSession`, open redirect 방지(`//` 거부), 실패 시 홈+`auth_error`
- `app/auth/callback/route.test.ts` — 5 케이스 (code 누락 / 교환 성공 / next 지정 / 외부경로 차단 / 교환 실패)

### 4. 의존성·env

- `@supabase/ssr@0.12.0` 추가, `supabase-js` 2.106.2 → 2.108.2 (peer 충족)
- `.env.example`에 공개 Supabase Auth 변수 2개

## 참고 사항

- 관련: #50, ADR 009
- **검증 수준**: 정적·단위 (typecheck / lint / 전체 테스트 96 통과). 실제 OAuth 로그인 플로우 E2E는 Supabase 대시보드 provider 설정 + 구글·카카오 콘솔 OAuth 앱 + env 주입이 필요하며 50-b/외부 설정 단계에서 검증.
- 후속: 50-b(로그인 UI + `/subscribe` 게이팅), 학습 문서(`@supabase/ssr` SSR 패턴)
