### PR TITLE
feat: 소셜 로그인 UI + 구독 게이팅 (#50, Step 50-b)

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -11,7 +11,7 @@
 
 Sprint 2 1번 작업(웹 푸시 파이프라인, #39)을 Step(9-a~d)으로 쪼개 진행 중. **9-a 완료·머지**(PR #47): VAPID 유틸 + Service Worker 등록 + 구독 훅 + 임시 검증 UI까지 클라이언트 구독 경로 완성, 실제 Chrome에서 구독→endpoint 생성 end-to-end 검증.
 
-**방향 전환(2026-06-25)**: 9-b 설계 중 서비스를 **로그인 사용자 기준**으로 운영하기로 결정 — 구독·발송·필터를 처음부터 `user_id`로 묶는다. 익명으로 먼저 만들면 나중에 user 연결 마이그레이션 + 고아 구독 정리로 두 번 일하므로, 순서를 바꿔 **소셜 로그인을 9-b 앞에 신규 편입**한다(근거: **ADR 009**). 이에 따라 ADR 008은 익명 → user 연결 모델로 **재작성**했고(`user_id` FK + RLS, endpoint UNIQUE·`410 Gone`은 유지), PROJECT_PLAN Sprint 2에 로그인을 편입했다(#50). 소셜 로그인은 50-a(SSR 기반)·50-b(로그인 UI + 게이팅)로 분할했고 **50-a 완료**(PR #52). 학습 문서(`docs/learning/step9-web-push.md`)는 발송까지 완결되는 9-c 시점에, `@supabase/ssr` SSR 패턴 학습 문서는 50 마무리 시점에 작성 예정.
+**방향 전환(2026-06-25)**: 9-b 설계 중 서비스를 **로그인 사용자 기준**으로 운영하기로 결정 — 구독·발송·필터를 처음부터 `user_id`로 묶는다. 익명으로 먼저 만들면 나중에 user 연결 마이그레이션 + 고아 구독 정리로 두 번 일하므로, 순서를 바꿔 **소셜 로그인을 9-b 앞에 신규 편입**한다(근거: **ADR 009**). 이에 따라 ADR 008은 익명 → user 연결 모델로 **재작성**했고(`user_id` FK + RLS, endpoint UNIQUE·`410 Gone`은 유지), PROJECT_PLAN Sprint 2에 로그인을 편입했다(#50). 소셜 로그인은 50-a(SSR 기반)·50-b(로그인 UI + 게이팅)로 분할했고 **둘 다 코드 완결**(50-a PR #52 머지, 50-b 구현·PR 대기). #50은 코드 기준 완결이며 실제 OAuth 로그인 E2E만 외부 설정(대시보드·콘솔·env) 후 남는다. 학습 문서: `@supabase/ssr` SSR 패턴은 **작성 완료**(`docs/learning/step50-supabase-ssr-auth.md`), 웹 푸시(`step9-web-push.md`)는 발송까지 완결되는 9-c 시점에 작성 예정.
 
 ### ✅ 해소됨 — 크롤 파이프라인 동결 (Issue #42, 2026-06-18)
 
@@ -19,21 +19,22 @@ Sprint 2 1번 작업(웹 푸시 파이프라인, #39)을 Step(9-a~d)으로 쪼�
 
 ### 완료된 Step
 
-| Step           | 내용                                                                                                                                     | 근거·산출물                                                                                         |
-| -------------- | ---------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------- |
-| Step 2         | Next.js 초기화, Prettier/husky/lint-staged, Vitest/Playwright                                                                            | `learning/step2-essentials`                                                                         |
-| Step 3         | Vercel 연동 + GitHub Actions CI (lint·tsc·test)                                                                                          | `learning/step3-ci-setup`                                                                           |
-| Step 4         | 크롤 파서 + DB 스키마 + 타입                                                                                                             | `learning/step4-{cheerio,vitest-basics,db-basics}` (※ `parseMainPage`·`checkBoardId`는 Step 6 폐기) |
-| Step 5-a~d     | fetch+retry / rateLimit / `announcementService` 합성 / MSW 통합테스트                                                                    | `learning/step5-{fetch-html,retry,rate-limit,msw-testing}`                                          |
-| Step 6         | 데이터 소스 재설계: JSON 목록(주) + view.do 하이브리드 (epic #19)                                                                        | ADR 002/003; PR #20~23·#25                                                                          |
-| Step 6 정리    | `checkBoardId` 모듈 실제 삭제 + 이슈 본문 정리                                                                                           | PR #27                                                                                              |
-| Step 7         | Supabase 저장 통합: admin 클라 + `announcements` UPSERT + `crawl_state` 리포                                                             | `learning/step7-*`; PR #29·#30                                                                      |
-| Step 8         | 크롤 스케줄러: `/api/cron/crawl` + `crawl.yml` (1h cron + dispatch), `CRON_SECRET` 인증                                                  | ADR 004; `learning/step8-gha-cron-vercel-trigger`; PR #35                                           |
-| Step 8 픽스    | 부트스트랩 catch-up 루프 픽스 — 시드 0이면 latestBoardId만 저장 (#36)                                                                    | ADR 005; `troubleshooting/2026-06-09-cron-bootstrap-catch-up`                                       |
-| 크롤 동결 픽스 | 동결 해소 (#42): gap-fill 폐기 → 목록 기반 크롤, 페이지네이션 보전, row별 격리. 프로덕션 500→200 검증                                    | ADR 007; PR #43·#45                                                                                 |
-| Step 9-a       | 웹 푸시 구독 클라 경로 (#39): VAPID 유틸 + SW 등록 + `usePushSubscription` 훅 + 임시 `/subscribe` UI. Chrome E2E 검증                    | PR #47 (서버 저장 9-b·발송 9-c)                                                                     |
-| Step 50-a      | 소셜 로그인 SSR 기반 (#50): `@supabase/ssr` browser/server 클라 + 세션 미들웨어 + OAuth 콜백 라우트. typecheck/lint/96 tests (정적·단위) | ADR 009; PR #52 (로그인 UI·게이팅 50-b)                                                             |
-| 운영·회고      | Sprint 1 운영 검증 (GHA dispatch 2회 success, `last_board_id` 6561 갱신) + Sprint 1 회고                                                 | `retrospectives/sprint-1`                                                                           |
+| Step           | 내용                                                                                                                                                                           | 근거·산출물                                                                                         |
+| -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------- |
+| Step 2         | Next.js 초기화, Prettier/husky/lint-staged, Vitest/Playwright                                                                                                                  | `learning/step2-essentials`                                                                         |
+| Step 3         | Vercel 연동 + GitHub Actions CI (lint·tsc·test)                                                                                                                                | `learning/step3-ci-setup`                                                                           |
+| Step 4         | 크롤 파서 + DB 스키마 + 타입                                                                                                                                                   | `learning/step4-{cheerio,vitest-basics,db-basics}` (※ `parseMainPage`·`checkBoardId`는 Step 6 폐기) |
+| Step 5-a~d     | fetch+retry / rateLimit / `announcementService` 합성 / MSW 통합테스트                                                                                                          | `learning/step5-{fetch-html,retry,rate-limit,msw-testing}`                                          |
+| Step 6         | 데이터 소스 재설계: JSON 목록(주) + view.do 하이브리드 (epic #19)                                                                                                              | ADR 002/003; PR #20~23·#25                                                                          |
+| Step 6 정리    | `checkBoardId` 모듈 실제 삭제 + 이슈 본문 정리                                                                                                                                 | PR #27                                                                                              |
+| Step 7         | Supabase 저장 통합: admin 클라 + `announcements` UPSERT + `crawl_state` 리포                                                                                                   | `learning/step7-*`; PR #29·#30                                                                      |
+| Step 8         | 크롤 스케줄러: `/api/cron/crawl` + `crawl.yml` (1h cron + dispatch), `CRON_SECRET` 인증                                                                                        | ADR 004; `learning/step8-gha-cron-vercel-trigger`; PR #35                                           |
+| Step 8 픽스    | 부트스트랩 catch-up 루프 픽스 — 시드 0이면 latestBoardId만 저장 (#36)                                                                                                          | ADR 005; `troubleshooting/2026-06-09-cron-bootstrap-catch-up`                                       |
+| 크롤 동결 픽스 | 동결 해소 (#42): gap-fill 폐기 → 목록 기반 크롤, 페이지네이션 보전, row별 격리. 프로덕션 500→200 검증                                                                          | ADR 007; PR #43·#45                                                                                 |
+| Step 9-a       | 웹 푸시 구독 클라 경로 (#39): VAPID 유틸 + SW 등록 + `usePushSubscription` 훅 + 임시 `/subscribe` UI. Chrome E2E 검증                                                          | PR #47 (서버 저장 9-b·발송 9-c)                                                                     |
+| Step 50-a      | 소셜 로그인 SSR 기반 (#50): `@supabase/ssr` browser/server 클라 + 세션 미들웨어 + OAuth 콜백 라우트. typecheck/lint/96 tests (정적·단위)                                       | ADR 009; PR #52 (로그인 UI·게이팅 50-b)                                                             |
+| Step 50-b      | 소셜 로그인 UI + 구독 게이팅 (#50): 구글·카카오 로그인/로그아웃 + `/subscribe` 게이팅 + `signInWithProvider`·`getSessionUser`. 103 tests (정적·단위, E2E는 외부 OAuth 설정 후) | ADR 009; `learning/step50-supabase-ssr-auth`                                                        |
+| 운영·회고      | Sprint 1 운영 검증 (GHA dispatch 2회 success, `last_board_id` 6561 갱신) + Sprint 1 회고                                                                                       | `retrospectives/sprint-1`                                                                           |
 
 > ADR 전체: `docs/adr/` — 001 기술스택, 002/003 데이터소스·매핑, 004 스케줄러, 005 부트스트랩, 006 크롤 출력 검증, 007 크롤 범위, 008 구독 저장 모델(user 연결), 009 소셜 로그인.
 
@@ -43,15 +44,17 @@ Sprint 2 1번 작업(웹 푸시 파이프라인, #39)을 Step(9-a~d)으로 쪼�
 
 ### 다음 할 일 — Sprint 2 (PROJECT_PLAN 4-1 참조)
 
-웹 푸시 파이프라인 (#39) 남은 Step (로그인 편입으로 재배열):
+소셜 로그인(#50)은 50-a·50-b로 **코드 완결** → 다음은 **9-b**.
 
-- **소셜 로그인 50-b (다음 · #50)**: 구글·카카오 로그인/로그아웃 UI(`signInWithOAuth({ provider })`) + `/subscribe`·`PushSubscribeButton` 비로그인 게이팅. 50-a(SSR 기반: 클라·미들웨어·콜백)는 **PR #52**로 완료 — 그 위에 얹는다. 범위·근거 **ADR 009**.
-  - **외부 선결(50-b E2E 전제, 사용자 작업)**: Supabase 대시보드 Google·Kakao provider 활성화 + client_id/secret + redirect allow-list / 구글·카카오 콘솔 OAuth 앱 등록 / env `NEXT_PUBLIC_SUPABASE_URL`·`NEXT_PUBLIC_SUPABASE_ANON_KEY` 주입(로컬 + Vercel). 미설정이어도 코드·단위 테스트는 진행 가능.
-- 9-b: 구독 저장 API + DB 스키마 (`push_subscriptions`) — `user_id` FK(NOT NULL) + endpoint UNIQUE + RLS. `POST /api/push/subscribe`는 세션에서 `user_id` 도출(비로그인 401). 모델·근거 **ADR 008**.
+- **외부 선결(#50 로그인 실제 E2E 전제, 사용자 작업)**: Supabase 대시보드 Google·Kakao provider 활성화 + client_id/secret + redirect allow-list / 구글·카카오 콘솔 OAuth 앱 등록 / env `NEXT_PUBLIC_SUPABASE_URL`·`NEXT_PUBLIC_SUPABASE_ANON_KEY` 주입(로컬 + Vercel). 미설정이어도 코드·단위 테스트는 진행 가능.
+
+웹 푸시 파이프라인 (#39) 남은 Step:
+
+- 9-b (다음): 구독 저장 API + DB 스키마 (`push_subscriptions`) — `user_id` FK(NOT NULL) + endpoint UNIQUE + RLS. `POST /api/push/subscribe`는 세션에서 `user_id` 도출(비로그인 401). 모델·근거 **ADR 008**.
 - 9-c: 발송 트리거(크롤 신규 감지와 연결) + `web-push` 통합 + `WHERE user_id`로 사용자 구독 조회 + `410 Gone` 만료 정리
 - 9-d: Playwright E2E (로그인 → 구독 → 신규 공고 → 알림 수신)
 
-**9-a 머지 코드 부채(로그인 편입에 따른 재작업)**: `usePushSubscription` 훅·`urlBase64ToUint8Array`·`sw.js`는 인증과 분리돼 무변경 재사용. `/subscribe` 페이지·`PushSubscribeButton`만 비로그인 시 로그인 유도로 게이팅 필요(표현 계층 한정).
+**9-a 머지 코드**: `usePushSubscription` 훅·`urlBase64ToUint8Array`·`sw.js`는 인증과 분리돼 무변경 재사용. `/subscribe` 게이팅은 **50-b에서 완료**(비로그인 시 로그인 유도, 로그인 시 구독 UI 노출).
 
 이후 Sprint 2 나머지:
 

--- a/docs/learning/step50-supabase-ssr-auth.md
+++ b/docs/learning/step50-supabase-ssr-auth.md
@@ -1,0 +1,165 @@
+# Supabase Auth SSR — 꼭 알아야 할 멘탈 모델
+
+`@supabase/ssr`로 Next.js(App Router)에 소셜 로그인을 붙일 때, 코드를 따라 치면 동작은 하지만 "왜 이렇게 생겼는지"가 안 보이면 디버깅이 지옥이 된다. 이 문서는 **그 구조를 떠받치는 핵심 개념 5가지**만 추린다. 청안 고유 결정(provider 선택, 게이팅 정책 등)은 ADR 009 소관이고, 여기 있는 건 어느 SSR 프로젝트에도 그대로 가져갈 수 있는 패턴이다.
+
+---
+
+## 1. 세션은 어디에 사는가 — localStorage가 아니라 "쿠키"
+
+가장 먼저 깨야 할 고정관념. 순수 클라이언트 앱(CSR)에서 Supabase는 세션(JWT 토큰)을 **localStorage**에 둔다. 그러면 서버는 그걸 못 읽는다 — localStorage는 브라우저만의 것이다.
+
+SSR에서는 서버 컴포넌트·미들웨어·Route Handler가 **"이 요청이 누구냐"를 알아야** 하므로, 세션을 **쿠키**에 둔다. 쿠키는 매 요청마다 자동으로 서버에 실려 가기 때문이다.
+
+```
+CSR:  세션 = localStorage  → 브라우저만 접근 가능
+SSR:  세션 = 쿠키          → 요청마다 서버에도 전달됨 ✅
+```
+
+이 한 줄이 아래 모든 구조의 출발점이다. "왜 클라이언트가 세 종류나 필요하지?"의 답이 전부 "쿠키를 누가, 어디서 읽고 쓰느냐"로 환원된다.
+
+---
+
+## 2. 클라이언트가 3개인 이유 — 실행 환경마다 쿠키 접근법이 다름
+
+`@supabase/ssr`을 쓰면 비슷해 보이는 Supabase 클라이언트를 **세 군데**서 만든다. 중복이 아니라, **각 실행 환경이 쿠키를 만지는 방법이 다르기 때문**이다.
+
+| 클라이언트     | 만드는 곳                     | 쿠키 접근 방법               | 역할                                    |
+| -------------- | ----------------------------- | ---------------------------- | --------------------------------------- |
+| **browser**    | 클라이언트 컴포넌트           | `document.cookie` (자동)     | 로그인 개시(`signInWithOAuth`)·로그아웃 |
+| **server**     | 서버 컴포넌트 / Route Handler | `next/headers`의 `cookies()` | 요청 주체가 누구인지 **읽기**           |
+| **middleware** | `middleware.ts`               | `request`/`response` 쿠키    | 세션 토큰 **갱신**(아래 4번)            |
+
+`createBrowserClient`는 쿠키를 알아서 처리하지만, `createServerClient`는 **쿠키 어댑터(`getAll`/`setAll`)를 직접 주입**해야 한다. 서버는 환경마다 쿠키를 읽고 쓰는 API가 다르기 때문(`cookies()` vs `request.cookies`)에, 그 차이를 어댑터로 메우는 구조다.
+
+### 서버 컴포넌트의 한계 — "쓰기"는 막혀 있다
+
+서버 컴포넌트(RSC)는 쿠키를 **읽을 순 있어도 쓸 수 없다**(HTTP 응답 헤더가 이미 스트리밍 중일 수 있어서). 그래서 server 클라이언트의 `setAll`은 보통 `try/catch`로 감싸고 실패를 무시한다.
+
+```ts
+setAll(cookiesToSet) {
+  try {
+    cookiesToSet.forEach(({ name, value, options }) =>
+      cookieStore.set(name, value, options),
+    );
+  } catch {
+    // 서버 컴포넌트에서는 쿠키 쓰기 불가 — 갱신은 미들웨어가 한다(4번)
+  }
+}
+```
+
+"그럼 토큰 갱신은 누가 하지?" → **미들웨어**다. 이게 미들웨어가 존재하는 이유다.
+
+---
+
+## 3. 세션 검증 — `getSession()`은 서버에서 신뢰하지 마라 (보안 핵심)
+
+서버에서 "지금 로그인한 사람"을 알아내는 메서드가 3개 있는데, **신뢰도가 다르다.** 이걸 모르면 인증을 우회당한다.
+
+| 메서드         | 동작                                           | 서버에서 신뢰?          |
+| -------------- | ---------------------------------------------- | ----------------------- |
+| `getSession()` | **쿠키 내용을 그대로** 반환. 검증 안 함        | ❌ 쿠키는 위조 가능     |
+| `getUser()`    | 매번 Supabase Auth 서버에 토큰 **재검증 요청** | ✅ (네트워크 비용 있음) |
+| `getClaims()`  | JWT **서명을 로컬 검증**(JWKS)                 | ✅ (보통 네트워크 없음) |
+
+**핵심**: 인가(authorization) 판단 — "이 사람을 들여보낼까?" — 은 절대 `getSession()`으로 하지 않는다. 쿠키는 클라이언트가 보내는 값이라 위조될 수 있고, `getSession()`은 그걸 검사 없이 믿는다. 라우트 보호·소유권 확인은 `getUser()` 또는 `getClaims()`로 한다.
+
+이 프로젝트는 `getClaims()`를 쓴다 — JWT 서명만 로컬에서 검증하면 되니 매 요청 네트워크 왕복이 없어 서버 컴포넌트에서 싸다. (왜 getClaims인지의 프로젝트 맥락은 ADR 009.)
+
+```ts
+const { data, error } = await supabase.auth.getClaims();
+const userId = data?.claims?.sub ?? null; // JWT의 sub = user id
+```
+
+---
+
+## 4. 미들웨어의 토큰 갱신 — 가장 안 직관적인 부분
+
+액세스 토큰은 짧게(기본 1시간) 만료된다. 만료되면 리프레시 토큰으로 새 토큰을 받아야 하는데, **서버 컴포넌트는 쿠키를 못 쓴다(2번)**. 그래서 **미들웨어가 매 요청 앞단에서 갱신을 대행**하고, 갱신된 쿠키를 양쪽에 심는다:
+
+- **요청(request) 쿠키**: 뒤이어 실행될 서버 컴포넌트가 새 토큰을 읽도록
+- **응답(response) 쿠키**: 브라우저가 새 토큰을 저장하도록
+
+```ts
+export async function updateSession(request: NextRequest) {
+  let response = NextResponse.next({ request });
+
+  const supabase = createServerClient(url, anonKey, {
+    cookies: {
+      getAll: () => request.cookies.getAll(),
+      setAll(cookiesToSet) {
+        // 1) 요청 쿠키 갱신 → 다운스트림 서버 컴포넌트가 읽음
+        cookiesToSet.forEach(({ name, value }) =>
+          request.cookies.set(name, value),
+        );
+        // 2) 응답 객체 재생성 후 응답 쿠키 갱신 → 브라우저가 저장
+        response = NextResponse.next({ request });
+        cookiesToSet.forEach(({ name, value, options }) =>
+          response.cookies.set(name, value, options),
+        );
+      },
+    },
+  });
+
+  // ⚠️ createServerClient와 이 호출 사이에 아무 코드도 넣지 말 것
+  await supabase.auth.getClaims(); // 이 호출이 토큰 갱신을 트리거
+
+  return response; // ⚠️ 반드시 이 response를 반환 (쿠키가 여기 담김)
+}
+```
+
+**두 개의 함정** (공식 문서가 굵게 경고하는 지점):
+
+1. **`createServerClient`와 `getClaims()`(또는 `getUser()`) 사이에 코드를 넣지 마라.** 그 사이에서 다른 작업을 하면 세션 갱신 타이밍이 어긋나 사용자가 **무작위로 로그아웃**되는, 재현 어려운 버그가 난다.
+2. **반드시 `supabaseResponse`를 반환하라.** 새 `NextResponse`를 직접 만들어 반환하면 갱신된 쿠키가 유실된다. 굳이 새 response가 필요하면 `response.cookies`를 복사해 옮겨야 한다.
+
+---
+
+## 5. OAuth 로그인의 리다이렉트 사슬 (PKCE)
+
+소셜 로그인은 "버튼 누르면 끝"이 아니라 **여러 번의 리다이렉트**다. 흐름을 그림으로 잡아두면 디버깅이 쉬워진다.
+
+```
+[클라이언트]  signInWithOAuth({ provider, options: { redirectTo } })
+      │        └ PKCE code_verifier를 쿠키에 저장하고
+      ▼
+[provider]    구글/카카오 로그인 화면 → 사용자 동의
+      │
+      ▼
+[콜백 라우트]  GET /auth/callback?code=xxx        ← provider가 돌려보냄
+      │        exchangeCodeForSession(code)
+      │        └ 쿠키의 code_verifier + code로 세션 토큰 교환 → 쿠키에 세션 심음
+      ▼
+[앱]          next 경로로 리다이렉트 (로그인 완료)
+```
+
+알아야 할 포인트:
+
+- **`redirectTo`는 콜백 라우트를 가리킨다.** provider 콘솔과 Supabase 대시보드의 allow-list에 이 URL이 등록돼 있어야 한다(미등록이면 provider가 거부). 외부 설정이 E2E의 전제가 되는 이유.
+- **콜백은 반드시 server 클라이언트로** `exchangeCodeForSession`을 호출한다. PKCE `code_verifier`가 1단계에서 쿠키에 저장됐고, 교환에는 그 쿠키가 필요하기 때문. browser 클라이언트로는 안 된다.
+- **`next`(복귀 경로)는 open redirect를 방어**해야 한다. 쿼리로 들어온 경로를 그대로 리다이렉트하면 `//evil.com` 같은 외부 URL로 튕길 수 있다. "`/`로 시작하고 `//`가 아닌" 내부 절대경로만 허용한다.
+
+```ts
+function sanitizeNext(next: string | null): string {
+  if (!next || !next.startsWith('/') || next.startsWith('//')) return '/';
+  return next;
+}
+```
+
+---
+
+## 6. 로그인 vs 열람의 책임 분리 (패턴)
+
+- **로그인 개시·로그아웃**은 브라우저에서 일어난다 → **클라이언트 컴포넌트** + browser 클라이언트.
+- **"로그인했나?" 판단(게이팅)** 은 서버에서 한다 → **서버 컴포넌트**에서 `getClaims()`로 읽고 분기.
+- 로그아웃 후엔 `router.refresh()`로 서버 컴포넌트를 다시 평가시켜야 게이팅 상태가 갱신된다(클라이언트 상태만 바꾸면 서버가 그린 화면은 그대로다).
+
+테스트 관점: `signInWithOAuth` 호출 인자(provider, redirectTo 구성)나 세션 클레임 파싱처럼 **분기·가공 로직은 순수 함수로 분리해 단위 테스트**하고, 버튼 JSX 같은 UI는 테스트하지 않는다. 실제 OAuth 왕복은 외부 콘솔 설정이 전제라 E2E로 미룬다.
+
+---
+
+## 7. 참고
+
+- Supabase SSR(Next.js) 공식 가이드: https://supabase.com/docs/guides/auth/server-side/nextjs
+- `getSession` vs `getUser` 보안 주의: https://supabase.com/docs/guides/auth/server-side/creating-a-client
+- PKCE flow: https://supabase.com/docs/guides/auth/sessions/pkce-flow
+- Next.js 미들웨어: https://nextjs.org/docs/app/building-your-application/routing/middleware

--- a/src/app/subscribe/page.tsx
+++ b/src/app/subscribe/page.tsx
@@ -1,16 +1,42 @@
+import { LoginButtons } from '@/components/auth/LoginButtons';
+import { LogoutButton } from '@/components/auth/LogoutButton';
 import { PushSubscribeButton } from '@/components/push/PushSubscribeButton';
+import { getSessionUser } from '@/lib/auth/getSessionUser';
 
 /**
- * 알림 구독 페이지 (임시 검증 단계, Step 9-a).
+ * 알림 구독 페이지 (임시 검증 단계, Step 9-a + 50-b 게이팅).
  *
- * 현재는 subscribe 흐름 검증용 최소 UI만 둔다.
- * 실제 디자인은 Sprint 2 화면이 모두 잡힌 뒤 v0/Lovable 등으로 일괄 작업한다.
+ * 구독은 로그인 사용자 기준으로 동작하므로(ADR 009), 비로그인 시 로그인 유도만
+ * 보여주고 구독 UI는 가린다. 공고 열람은 공개지만 구독 액션은 인증을 요구한다.
+ *
+ * 현재는 흐름 검증용 최소 UI다. 실제 디자인은 Sprint 2 화면이 모두 잡힌 뒤
+ * v0/Lovable 등으로 일괄 작업한다.
  */
-export default function SubscribePage() {
+export default async function SubscribePage() {
+  const user = await getSessionUser();
+
   return (
     <main className="mx-auto max-w-md p-8">
       <h1 className="mb-4 text-xl font-bold">알림 구독 (임시)</h1>
-      <PushSubscribeButton />
+
+      {user ? (
+        <div className="flex flex-col gap-4">
+          <div className="flex items-center justify-between gap-3">
+            <span className="text-sm text-zinc-600">
+              {user.email ?? '로그인됨'}
+            </span>
+            <LogoutButton />
+          </div>
+          <PushSubscribeButton />
+        </div>
+      ) : (
+        <div className="flex flex-col gap-3">
+          <p className="text-sm text-zinc-600">
+            알림을 구독하려면 먼저 로그인하세요.
+          </p>
+          <LoginButtons next="/subscribe" />
+        </div>
+      )}
     </main>
   );
 }

--- a/src/components/auth/LoginButtons.tsx
+++ b/src/components/auth/LoginButtons.tsx
@@ -1,0 +1,57 @@
+'use client';
+
+import { useState } from 'react';
+
+import {
+  signInWithProvider,
+  type SocialProvider,
+} from '@/lib/auth/signInWithProvider';
+
+const PROVIDERS: { provider: SocialProvider; label: string }[] = [
+  { provider: 'google', label: 'Google로 로그인' },
+  { provider: 'kakao', label: '카카오로 로그인' },
+];
+
+interface LoginButtonsProps {
+  /** 로그인 후 복귀할 앱 내부 경로 */
+  next?: string;
+}
+
+/**
+ * 소셜 로그인 버튼(구글·카카오). 클릭 시 provider 인증 페이지로 이동한다.
+ *
+ * 실제 디자인은 Sprint 2 화면이 모두 잡힌 뒤 일괄 작업한다(임시 UI). (ADR 009)
+ */
+export function LoginButtons({ next = '/' }: LoginButtonsProps) {
+  const [pending, setPending] = useState<SocialProvider | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  async function handleClick(provider: SocialProvider) {
+    setPending(provider);
+    setError(null);
+    const { error } = await signInWithProvider(provider, next);
+    // 성공 시 브라우저가 provider로 리다이렉트되므로 이 줄에 도달하지 않는다.
+    if (error) {
+      setError(error.message);
+      setPending(null);
+    }
+  }
+
+  return (
+    <div className="flex flex-col gap-3">
+      {PROVIDERS.map(({ provider, label }) => (
+        <button
+          key={provider}
+          type="button"
+          onClick={() => void handleClick(provider)}
+          disabled={pending !== null}
+          className="w-fit rounded border px-4 py-2 disabled:opacity-50"
+        >
+          {pending === provider ? '이동 중…' : label}
+        </button>
+      ))}
+
+      {error && <p className="text-sm text-red-600">로그인 오류: {error}</p>}
+    </div>
+  );
+}

--- a/src/components/auth/LogoutButton.tsx
+++ b/src/components/auth/LogoutButton.tsx
@@ -1,0 +1,33 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { useState } from 'react';
+
+import { getSupabaseBrowserClient } from '@/lib/supabase/browserClient';
+
+/**
+ * 로그아웃 버튼. 쿠키 세션을 제거한 뒤 현재 라우트를 새로고침해
+ * 서버 컴포넌트의 로그인 상태(게이팅)를 다시 평가하게 한다. (ADR 009)
+ */
+export function LogoutButton() {
+  const router = useRouter();
+  const [pending, setPending] = useState(false);
+
+  async function handleClick() {
+    setPending(true);
+    await getSupabaseBrowserClient().auth.signOut();
+    router.refresh();
+    setPending(false);
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={() => void handleClick()}
+      disabled={pending}
+      className="w-fit rounded border px-4 py-2 disabled:opacity-50"
+    >
+      {pending ? '로그아웃 중…' : '로그아웃'}
+    </button>
+  );
+}

--- a/src/lib/auth/getSessionUser.test.ts
+++ b/src/lib/auth/getSessionUser.test.ts
@@ -1,0 +1,61 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/lib/supabase/serverClient', () => ({
+  getSupabaseServerClient: vi.fn(),
+}));
+
+import { getSupabaseServerClient } from '@/lib/supabase/serverClient';
+
+import { getSessionUser } from './getSessionUser';
+
+type GetClaimsResult = {
+  data: { claims: Record<string, unknown> } | null;
+  error: unknown;
+};
+
+function mockServerClient(result: GetClaimsResult): void {
+  const client = {
+    auth: { getClaims: vi.fn().mockResolvedValue(result) },
+  };
+  vi.mocked(getSupabaseServerClient).mockResolvedValue(
+    client as unknown as Awaited<ReturnType<typeof getSupabaseServerClient>>,
+  );
+}
+
+describe('getSessionUser', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('유효한 클레임이면 userId·email을 도출한다', async () => {
+    mockServerClient({
+      data: { claims: { sub: 'user-123', email: 'a@b.com' } },
+      error: null,
+    });
+
+    expect(await getSessionUser()).toEqual({
+      userId: 'user-123',
+      email: 'a@b.com',
+    });
+  });
+
+  it('email 클레임이 없으면 email은 null', async () => {
+    mockServerClient({ data: { claims: { sub: 'user-123' } }, error: null });
+
+    expect(await getSessionUser()).toEqual({ userId: 'user-123', email: null });
+  });
+
+  it('error가 있으면 null', async () => {
+    mockServerClient({ data: null, error: new Error('invalid') });
+
+    expect(await getSessionUser()).toBeNull();
+  });
+
+  it('claims 또는 sub가 없으면 null(비로그인)', async () => {
+    mockServerClient({ data: null, error: null });
+    expect(await getSessionUser()).toBeNull();
+
+    mockServerClient({ data: { claims: {} }, error: null });
+    expect(await getSessionUser()).toBeNull();
+  });
+});

--- a/src/lib/auth/getSessionUser.ts
+++ b/src/lib/auth/getSessionUser.ts
@@ -1,0 +1,29 @@
+/**
+ * 서버(서버 컴포넌트 / Route Handler / 서버 액션)에서 현재 로그인한
+ * 사용자를 도출한다. 로그인 게이팅과 9-b 구독 저장의 단일 진입점이다.
+ *
+ * 세션 검증은 `getClaims()`로 한다(ADR 009) — 미들웨어가 갱신한 쿠키 세션의
+ * JWT 클레임을 읽는다. 비로그인·검증 실패 시 null을 반환한다.
+ */
+
+import { getSupabaseServerClient } from '@/lib/supabase/serverClient';
+
+export interface SessionUser {
+  /** Supabase `auth.users.id` (JWT `sub`). 구독 등 소유권의 기준 */
+  userId: string;
+  /** provider가 제공한 이메일. 없으면 null */
+  email: string | null;
+}
+
+export async function getSessionUser(): Promise<SessionUser | null> {
+  const supabase = await getSupabaseServerClient();
+  const { data, error } = await supabase.auth.getClaims();
+
+  if (error || !data?.claims?.sub) return null;
+
+  const { sub, email } = data.claims;
+  return {
+    userId: sub,
+    email: typeof email === 'string' ? email : null,
+  };
+}

--- a/src/lib/auth/signInWithProvider.test.ts
+++ b/src/lib/auth/signInWithProvider.test.ts
@@ -1,0 +1,56 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/lib/supabase/browserClient', () => ({
+  getSupabaseBrowserClient: vi.fn(),
+}));
+
+import { getSupabaseBrowserClient } from '@/lib/supabase/browserClient';
+
+import { signInWithProvider } from './signInWithProvider';
+
+function mockBrowserClient(result: { error: unknown } = { error: null }) {
+  const signInWithOAuth = vi.fn().mockResolvedValue(result);
+  vi.mocked(getSupabaseBrowserClient).mockReturnValue({
+    auth: { signInWithOAuth },
+  } as unknown as ReturnType<typeof getSupabaseBrowserClient>);
+  return signInWithOAuth;
+}
+
+describe('signInWithProvider', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('provider와 next를 담은 콜백 redirectTo로 signInWithOAuth 호출', async () => {
+    const signInWithOAuth = mockBrowserClient();
+
+    await signInWithProvider('google', '/subscribe');
+
+    expect(signInWithOAuth).toHaveBeenCalledWith({
+      provider: 'google',
+      options: {
+        redirectTo: `${window.location.origin}/auth/callback?next=%2Fsubscribe`,
+      },
+    });
+  });
+
+  it('next 미지정 시 기본 홈(/)으로 복귀하도록 인코딩', async () => {
+    const signInWithOAuth = mockBrowserClient();
+
+    await signInWithProvider('kakao');
+
+    expect(signInWithOAuth).toHaveBeenCalledWith({
+      provider: 'kakao',
+      options: {
+        redirectTo: `${window.location.origin}/auth/callback?next=%2F`,
+      },
+    });
+  });
+
+  it('signInWithOAuth 오류를 그대로 전달', async () => {
+    const error = new Error('oauth failed');
+    mockBrowserClient({ error });
+
+    expect(await signInWithProvider('google')).toEqual({ error });
+  });
+});

--- a/src/lib/auth/signInWithProvider.ts
+++ b/src/lib/auth/signInWithProvider.ts
@@ -1,0 +1,28 @@
+/**
+ * 소셜 로그인 개시 로직(클라이언트). 버튼 JSX에서 분리해 테스트 가능하게 둔다.
+ *
+ * provider 인증 페이지로 보내며, 인증 후 `/auth/callback`으로 돌아와 세션을
+ * 교환한 뒤 `next` 경로로 복귀한다(콜백 라우트가 open-redirect를 방어). (ADR 009)
+ */
+
+import { getSupabaseBrowserClient } from '@/lib/supabase/browserClient';
+
+/** ADR 009: 구글·카카오만 도입(YAGNI) */
+export type SocialProvider = 'google' | 'kakao';
+
+export async function signInWithProvider(
+  provider: SocialProvider,
+  next = '/',
+): Promise<{ error: Error | null }> {
+  const redirectTo = `${window.location.origin}/auth/callback?next=${encodeURIComponent(
+    next,
+  )}`;
+
+  const supabase = getSupabaseBrowserClient();
+  const { error } = await supabase.auth.signInWithOAuth({
+    provider,
+    options: { redirectTo },
+  });
+
+  return { error };
+}


### PR DESCRIPTION
## Summary

소셜 로그인(#50)의 **Step 50-b — 로그인 UI + 구독 게이팅**입니다. 50-a(SSR 기반, PR #52 머지) 위에 구글·카카오 로그인/로그아웃 UI와 `/subscribe` 인증 게이팅을 얹습니다. 이로써 #50 코드가 완결됩니다. (설계·근거: ADR 009)

## 주요 변경 사항

### 1. 인증 동작 (lib/auth)

- `lib/auth/signInWithProvider.ts` — 구글·카카오 `signInWithOAuth`, 콜백 `next` 전달 (+ test)
- `lib/auth/getSessionUser.ts` — 서버에서 세션 사용자 조회 (+ test)

### 2. 로그인 UI (components/auth)

- `LoginButtons.tsx` — 구글·카카오 로그인 버튼
- `LogoutButton.tsx` — 로그아웃

### 3. 구독 게이팅

- `/subscribe`: 비로그인 시 로그인 유도(`LoginButtons`), 로그인 시에만 구독 UI 노출 — 9-a에서 남긴 게이팅 부채 해소

### 4. 학습 문서

- `docs/learning/step50-supabase-ssr-auth.md` — `@supabase/ssr` SSR 인증 패턴 정리

## 참고 사항

- 관련: #50, ADR 009. 50-a는 PR #52로 머지됨(이 브랜치는 그 위 50-b 커밋만 포함)
- **검증 수준**: 정적·단위 (typecheck / lint / 전체 테스트 103 통과). 실제 OAuth 로그인 E2E는 외부 선결 후 — Supabase 대시보드 Google·Kakao provider + client_id/secret + redirect allow-list / 구글·카카오 콘솔 OAuth 앱 / env `NEXT_PUBLIC_SUPABASE_URL`·`NEXT_PUBLIC_SUPABASE_ANON_KEY` 주입
- HANDOFF §0을 50-b 완료로 갱신 (다음: 9-b)
