### PR TITLE
feat: 웹 푸시 구독 저장 — L1/L2 분리 모델 (#39, Step 9-b)

### DIFF
--- a/docs/adr/008-push-subscription-model.md
+++ b/docs/adr/008-push-subscription-model.md
@@ -1,13 +1,13 @@
-# ADR 008: 웹 푸시 구독 저장 모델 — user 연결 구독, endpoint 기기 식별, expiration_time 생략
+# ADR 008: 웹 푸시 구독 저장 모델 — 구독 의사(계정)/배달 채널(계정×기기) 분리
 
 - **상태**: 승인됨
-- **작성일**: 2026-06-25
+- **작성일**: 2026-06-25 (개정 2026-07-03: endpoint 단독 UNIQUE 모델 폐기 → L1/L2 분리)
 - **관련 이슈**: #39 (Step 9-b)
 - **관련 ADR**: 009 (소셜 로그인 도입) — 이 결정의 전제
 
 ## 맥락
 
-웹 푸시 파이프라인(#39)의 9-b에서 브라우저가 생성한 `PushSubscription`을 저장할 `push_subscriptions` 스키마와 저장 정책을 정해야 한다.
+웹 푸시 파이프라인(#39)의 9-b에서 브라우저가 생성한 `PushSubscription`을 저장할 스키마와 저장 정책을 정해야 한다.
 
 브라우저의 `PushSubscription.toJSON()`은 다음 형태다:
 
@@ -23,48 +23,75 @@
 
 > **전제 변경(2026-06-25)**: 이 ADR의 최초안은 "MVP에 로그인 없음"을 전제로 **익명 구독**을 택했으나, ADR 009로 **소셜 로그인을 Sprint 2에 도입**하기로 결정하면서 그 전제가 깨졌다. 이제 구독은 항상 로그인한 사용자에 묶인다. 구독별 조건(지역구·공고 유형 필터)은 Sprint 3에서 `user_id` 기준으로 붙는다.
 
-결정해야 할 점: (1) 같은 사용자의 여러 기기를 어떻게 표현하나, (2) 중복/재구독을 무엇으로 식별하나, (3) `expirationTime`을 저장하나.
+### 요구사항 (2026-07-03 확정)
+
+구독 상태는 **계정의 속성**이다:
+
+- **상황 1 (계정별 독립)**: 같은 기기 X에서 계정 A의 구독/해제와 계정 B의 구독/해제는 서로 영향을 주지 않는다.
+- **상황 2 (기기 간 공유)**: 같은 계정 A라면 기기 X에서의 구독/해제 상태가 기기 Y에도 공유된다 — X에서 끄면 Y도 발송이 중단된다.
+
+### 못 바꾸는 물리 제약 (웹 푸시 표준)
+
+1. **알림 권한 + 구독(endpoint)은 브라우저마다 개별이다.** 계정으로 공유하거나 자동 이전할 수 없다. A가 폰에서 구독했어도 새 노트북에서는 다시 권한 허용 + 구독을 해야 알림을 받는다.
+2. **한 브라우저 = 물리 채널(endpoint) 하나.** 그 채널로 도착한 알림은 누가 로그인해 있든 그 브라우저 화면에 뜬다. 서비스워커는 로그인 상태로 수신자를 거르지 못한다.
+
+→ DB 상태는 계정별로 완벽히 독립시킬 수 있지만, **공유 브라우저에서 화면의 물리적 격리는 불가능하다**. 공고 알림은 민감도가 낮아 MVP에서 수용한다.
 
 ## 고려한 선택지
 
-### 선택지 1: user_id FK(NOT NULL) + endpoint UNIQUE + expiration_time 생략
+### 선택지 1: 구독 의사(L1)/배달 채널(L2) 분리 + `UNIQUE(user_id, endpoint)` — 채택
 
-구독을 `user_id`(→ `auth.users`)로 소유시키되, `endpoint`에 UNIQUE 제약을 걸어 기기를 식별하고 재구독을 UPSERT로 멱등 처리한다. `expirationTime`은 컬럼으로 두지 않는다.
+한 row에 뭉쳐 있던 "구독 의사"와 "배달 채널"을 두 테이블로 나눈다:
 
-- 장점: ADR 009의 로그인 모델을 그대로 반영. 발송 시 `WHERE user_id = ?`로 그 사용자의 모든 기기 구독을 조회한다.
-- 장점: endpoint는 푸시 서비스가 구독마다 발급하는 고유 URL → 자연스러운 기기 중복 키. 한 사용자가 폰·노트북 등 **여러 기기**를 구독하면 같은 `user_id`의 여러 row가 되고, 같은 기기가 재구독하면 같은(또는 갱신된) endpoint로 UPSERT되어 row 폭증이 없다.
-- 장점: RLS로 `user_id = auth.uid()` 본인 row만 접근하도록 DB가 소유권을 강제할 수 있다.
-- 장점: `expirationTime`은 실제로 대부분 `null`이며, 만료/거부 정리는 발송 시점의 `410 Gone` 응답으로 처리(9-c)하는 게 더 정확하다(저장된 만료 시각을 신뢰하는 것보다). — 로그인과 무관하게 유효한 판단이라 최초안에서 그대로 살린다.
+| 레이어       | 테이블               | 무엇                                                                    | 단위                                       | 담당 요구     |
+| ------------ | -------------------- | ----------------------------------------------------------------------- | ------------------------------------------ | ------------- |
+| L1 구독 의사 | `push_preferences`   | "이 계정이 알림을 원한다" (`enabled` 플래그, Sprint 3 필터가 붙을 자리) | 계정 (`user_id` UNIQUE)                    | 상황 2 (공유) |
+| L2 배달 채널 | `push_subscriptions` | endpoint + keys                                                         | (계정, 기기) — `UNIQUE(user_id, endpoint)` | 상황 1 (독립) |
+
+- 장점: L1이 계정 단위라 A와 B의 의사가 애초에 별개 row — 상황 1 성립. 어느 기기에서 끄든 계정 차원에서 꺼져 상황 2(해제 공유)도 성립.
+- 장점: L2 키에 `user_id`가 들어가 같은 기기의 {A, endpoint}·{B, endpoint}가 공존 — 계정 간 endpoint 소유권 충돌이 구조적으로 사라진다.
+- 장점: 발송(9-c)은 "L1 enabled인 계정의 모든 L2 채널로 발송(`WHERE user_id = ?`)" — 단순한 조인.
 
 ### 선택지 2: 익명 독립 row (최초안) — 폐기
 
 구독을 사용자에 묶지 않고 endpoint UNIQUE만으로 독립 row 저장.
 
-- 폐기 사유: ADR 009로 로그인이 확정됐다. 익명으로 만들면 나중에 `user_id` 추가 마이그레이션 + 로그인 전 생긴 **고아 익명 구독**을 사용자에 연결하는 처리가 필요하다 — 처음부터 user 연결로 만들면 이 비용이 전부 0이다.
+- 폐기 사유: ADR 009로 로그인이 확정됐다. 익명으로 만들면 나중에 `user_id` 추가 마이그레이션 + 고아 익명 구독 연결 처리가 필요하다 — 처음부터 user 연결로 만들면 이 비용이 전부 0이다.
 
-### 선택지 3: 사용자당 단일 구독 (endpoint UNIQUE 없이 user_id UNIQUE)
+### 선택지 3: 사용자당 단일 구독 (`user_id` UNIQUE) — 폐기
 
-`user_id`를 UNIQUE로 두어 사용자당 row 1개만 유지.
+- 폐기 사유: 한 사용자가 여러 기기에서 알림을 받지 못한다(마지막 구독 기기로 덮어써짐). 멀티기기는 웹 푸시의 자연스러운 사용 패턴이다.
 
-- 단점: 한 사용자가 여러 기기에서 알림을 받지 못한다(마지막 구독 기기로 덮어써짐). 멀티기기는 웹 푸시의 자연스러운 사용 패턴이라 잃을 이유가 없다.
+### 선택지 4: 단일 테이블 + `endpoint` 단독 UNIQUE (2026-06-25 개정안) — 폐기
+
+구독 의사와 배달 채널을 한 row에 두고, endpoint를 단독 UNIQUE 키로 UPSERT. 같은 기기에서 다른 계정이 재구독하면 RLS 충돌을 409로 표면화(소유권은 선점 계정에 고정).
+
+- 폐기 사유(상황 1 위반): endpoint가 계정 간 배타 자원이 되어, 기기 X에서 B는 A가 점유한 채널 때문에 구독 자체가 막힌다(409). "계정별 독립"과 정반대.
+- 폐기 사유(상황 2 위반): "구독 = row 존재"라서 기기 X에서 해제해도 기기 Y의 row는 남는다 — 계정 단위 OFF(해제 공유)를 표현할 수 없다.
 
 ## 결정
 
-선택지 1 — 구독을 `user_id`(NOT NULL, → `auth.users`)로 소유시키고, `endpoint`를 UNIQUE 키로 삼아 UPSERT로 멱등 처리한다. RLS로 본인 row만 접근하게 한다. `expiration_time`은 저장하지 않고 만료 정리는 발송 시 `410 Gone`(9-c)으로 한다.
+선택지 1 — 구독 의사(L1 `push_preferences`, 계정당 1 row + `enabled`)와 배달 채널(L2 `push_subscriptions`, `UNIQUE(user_id, endpoint)`)을 분리한다. 두 테이블 모두 `user_id`(NOT NULL, → `auth.users`) 소유 + RLS로 본인 row만 접근. `expiration_time`은 저장하지 않고 만료 정리는 발송 시 `410 Gone`(9-c)으로 한다.
 
 ## 근거
 
-- ADR 009로 로그인이 확정됐으므로 처음부터 user 연결 모델로 만들어 재작업(익명 구현 + 마이그레이션 + 고아 구독 연결)을 0으로 만든다.
-- endpoint는 푸시 서비스가 보장하는 자연 고유 키라 기기 식별·재구독 멱등에 별도 식별자나 중복 정리 로직이 필요 없다. user_id와 함께 두면 "사용자 → 기기들" 관계가 그대로 표현된다.
-- 만료는 저장된 시각이 아니라 발송 결과(`410 Gone`)가 진실의 원천이다 — `expiration_time` 컬럼은 신뢰도 낮은 중복 정보.
+- 요구사항 두 축(계정별 독립, 기기 간 공유)이 서로 다른 단위(계정×기기, 계정)를 가리키므로 한 테이블로는 표현이 안 된다 — 분리가 최소 모델이다.
+- L2 키에 user_id를 포함하면 계정 간 충돌(409)이 구조적으로 소멸 — 에러 처리 분기 자체가 사라진다.
+- `expirationTime`은 실제로 대부분 `null`이며, 만료/거부 정리는 발송 시점의 `410 Gone` 응답으로 처리(9-c)하는 게 더 정확하다(저장된 만료 시각을 신뢰하는 것보다).
+- Sprint 3의 지역구/유형 필터는 "계정의 알림 조건"이므로 L1에 자연스럽게 붙는다 — 재작업 없음.
 
 ## 결과
 
 - 마이그레이션 `supabase/migrations/00002_create_push_subscriptions.sql`:
-  - `push_subscriptions(id, user_id NOT NULL → auth.users(id), endpoint UNIQUE, p256dh, auth, user_agent, created_at, updated_at)`.
+  - `push_preferences(id, user_id UNIQUE NOT NULL → auth.users(id), enabled, created_at, updated_at)`.
+  - `push_subscriptions(id, user_id NOT NULL → auth.users(id), endpoint, p256dh, auth, user_agent, created_at, updated_at, UNIQUE(user_id, endpoint))`.
   - 기존 `update_updated_at()` 트리거 함수 재사용.
-  - **RLS 활성화**: 본인 row만 `select`/`insert`/`delete` (`user_id = auth.uid()`). (announcements는 admin 전용 쓰기라 RLS 미적용이었으나, 사용자 소유 데이터인 구독은 RLS로 보호한다.)
-- 리포지터리 `pushSubscriptionsRepository`: 순수 매퍼 + `endpoint` 충돌 키 UPSERT(기존 announcements 패턴 답습), `user_id` 포함.
-- 라우트 `POST /api/push/subscribe`: 세션에서 `user_id`를 도출(ADR 009의 `getClaims()`), `PushSubscription.toJSON()` 형태 수신, 비로그인 401, 필수 필드 검증(400) 후 UPSERT(성공 201, DB 예외 500). 쓰기는 admin 클라가 아니라 **세션 바인딩된 server 클라**로 수행해 RLS가 소유권을 강제하게 한다(최종 형태는 9-b 구현에서 확정).
-- 발송(9-c): `WHERE user_id = ?`로 해당 사용자의 구독을 조회해 endpoint마다 발송. `410 Gone` 정리는 endpoint로 row를 삭제한다(`deletePushSubscriptionByEndpoint`).
-- **Sprint 3 영향**: 지역구/유형 필터는 `user_id` 기준 구독 row에 필터 조건 컬럼(또는 별도 구독-조건 테이블)을 붙이는 방향으로 확장한다. 처음부터 user 기준이라 재작업이 없다.
+  - **RLS 활성화 (두 테이블)**: 본인 row만 `select`/`insert`/`update`/`delete` (`user_id = auth.uid()`). `update` 정책은 UPSERT가 충돌 시 내부적으로 UPDATE를 실행하므로 필수(없으면 재구독 키 갱신·enabled 토글이 실패). (announcements는 admin 전용 쓰기라 RLS 미적용이었으나, 사용자 소유 데이터인 구독은 RLS로 보호한다.)
+- 리포지터리: `pushSubscriptionsRepository`(순수 매퍼 + `user_id,endpoint` 충돌 키 UPSERT), `pushPreferencesRepository`(`setPushPreference` user_id 충돌 UPSERT, `getPushPreference` row 없으면 false).
+- 라우트 `/api/push/subscribe`: 쓰기는 admin 클라가 아니라 **세션 바인딩된 server 클라**로 수행해 RLS가 소유권을 강제하게 한다.
+  - `POST` = 구독 켜기: 세션에서 `user_id` 도출(ADR 009의 `getClaims()`), `PushSubscription.toJSON()` 수신, 비로그인 401, 필드 검증 400, L2 UPSERT + L1 `enabled=true` 후 201, DB 예외 500.
+  - `DELETE` = 구독 끄기: L1 `enabled=false`만. L2 row·브라우저 채널은 보존 — 같은 기기의 다른 계정 채널을 보호하고, 죽은 채널 정리는 9-c의 `410 Gone`이 담당.
+- UI(`/subscribe`): 서버 컴포넌트가 L1 상태를 조회해 토글로 노출. 계정 구독이 켜져 있어도 이 브라우저에 채널이 없으면 "이 기기에서도 알림 받기"를 따로 노출한다(물리 제약 1 — 권한·채널은 브라우저별 개별).
+  - **마운트 재동기화**: 계정 구독 ON + 브라우저 채널 존재 시 멱등 POST 1회 — 브라우저 채널 존재만으로는 현재 계정의 L2 row가 보장되지 않으므로(공유 브라우저에서 타 계정이 만든 채널일 수 있음) 항상 동기화한다. 키 회전 치유 겸용. 수용한 트레이드오프: 공유 브라우저에서 페이지 방문만으로 그 기기가 현재 계정의 채널로 등록되고(암묵적 opt-in), 다계정 공존 시 같은 화면에 중복 알림이 뜰 수 있다 — 공고 알림의 낮은 민감도로 MVP에서 수용.
+- 발송(9-c): L1 `enabled = true`인 계정의 L2 채널을 `WHERE user_id`로 조회해 endpoint마다 발송. `410 Gone` 정리는 endpoint로 해당 채널 row를 삭제한다.
+- **Sprint 3 영향**: 지역구/유형 필터는 L1 `push_preferences`에 조건 컬럼(또는 별도 조건 테이블)으로 확장한다. 처음부터 계정 기준이라 재작업이 없다.

--- a/src/app/api/push/subscribe/route.test.ts
+++ b/src/app/api/push/subscribe/route.test.ts
@@ -1,0 +1,179 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/lib/auth/getSessionUser', () => ({
+  getSessionUser: vi.fn(),
+}));
+vi.mock('@/lib/supabase/serverClient', () => ({
+  getSupabaseServerClient: vi.fn(),
+}));
+vi.mock(
+  '@/lib/supabase/pushSubscriptionsRepository',
+  async (importOriginal) => {
+    const original =
+      await importOriginal<
+        typeof import('@/lib/supabase/pushSubscriptionsRepository')
+      >();
+    return {
+      ...original,
+      upsertPushSubscription: vi.fn(),
+    };
+  },
+);
+vi.mock('@/lib/supabase/pushPreferencesRepository', () => ({
+  setPushPreference: vi.fn(),
+}));
+
+import { getSessionUser } from '@/lib/auth/getSessionUser';
+import { setPushPreference } from '@/lib/supabase/pushPreferencesRepository';
+import { upsertPushSubscription } from '@/lib/supabase/pushSubscriptionsRepository';
+import { getSupabaseServerClient } from '@/lib/supabase/serverClient';
+
+import { DELETE, POST } from './route';
+
+const USER_ID = 'b7e6a4c2-0000-4000-8000-000000000001';
+
+function buildBody(overrides: Record<string, unknown> = {}) {
+  return {
+    endpoint: 'https://fcm.googleapis.com/fcm/send/abc123',
+    keys: { p256dh: 'p256dh-key', auth: 'auth-secret' },
+    ...overrides,
+  };
+}
+
+function makeRequest(body: unknown, userAgent?: string): Request {
+  const headers: Record<string, string> = {
+    'content-type': 'application/json',
+  };
+  if (userAgent !== undefined) headers['user-agent'] = userAgent;
+  return new Request('http://localhost/api/push/subscribe', {
+    method: 'POST',
+    headers,
+    body: typeof body === 'string' ? body : JSON.stringify(body),
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(getSessionUser).mockResolvedValue({
+    userId: USER_ID,
+    email: 'user@example.com',
+  });
+  vi.mocked(getSupabaseServerClient).mockResolvedValue(
+    {} as Awaited<ReturnType<typeof getSupabaseServerClient>>,
+  );
+  vi.mocked(upsertPushSubscription).mockResolvedValue(undefined);
+  vi.mocked(setPushPreference).mockResolvedValue(undefined);
+});
+
+describe('POST /api/push/subscribe', () => {
+  it('비로그인이면 401을 반환하고 저장하지 않는다', async () => {
+    vi.mocked(getSessionUser).mockResolvedValue(null);
+
+    const response = await POST(makeRequest(buildBody()));
+
+    expect(response.status).toBe(401);
+    expect(upsertPushSubscription).not.toHaveBeenCalled();
+    expect(setPushPreference).not.toHaveBeenCalled();
+  });
+
+  it('body가 JSON이 아니면 400', async () => {
+    const response = await POST(makeRequest('not-json'));
+
+    expect(response.status).toBe(400);
+    expect(upsertPushSubscription).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ['endpoint 누락', buildBody({ endpoint: undefined })],
+    ['endpoint 빈 문자열', buildBody({ endpoint: '' })],
+    ['keys 누락', buildBody({ keys: undefined })],
+    ['p256dh 누락', buildBody({ keys: { auth: 'auth-secret' } })],
+    ['auth 누락', buildBody({ keys: { p256dh: 'p256dh-key' } })],
+  ])('필수 필드 검증 실패(%s)면 400', async (_label, body) => {
+    const response = await POST(makeRequest(body));
+
+    expect(response.status).toBe(400);
+    expect(upsertPushSubscription).not.toHaveBeenCalled();
+  });
+
+  it('유효한 구독이면 L2 채널 UPSERT + L1 enabled=true 후 201', async () => {
+    const response = await POST(makeRequest(buildBody(), 'Mozilla/5.0'));
+
+    expect(response.status).toBe(201);
+    expect(upsertPushSubscription).toHaveBeenCalledTimes(1);
+    const [, row] = vi.mocked(upsertPushSubscription).mock.calls[0];
+    expect(row).toEqual({
+      user_id: USER_ID,
+      endpoint: 'https://fcm.googleapis.com/fcm/send/abc123',
+      p256dh: 'p256dh-key',
+      auth: 'auth-secret',
+      user_agent: 'Mozilla/5.0',
+    });
+    expect(setPushPreference).toHaveBeenCalledWith(
+      expect.anything(),
+      USER_ID,
+      true,
+    );
+  });
+
+  it('user-agent 헤더가 없으면 null로 저장한다', async () => {
+    await POST(makeRequest(buildBody()));
+
+    const [, row] = vi.mocked(upsertPushSubscription).mock.calls[0];
+    expect(row.user_agent).toBeNull();
+  });
+
+  it('채널 UPSERT가 실패하면 500, L1은 건드리지 않는다', async () => {
+    vi.mocked(upsertPushSubscription).mockRejectedValue(
+      new Error('connection refused'),
+    );
+
+    const response = await POST(makeRequest(buildBody()));
+
+    expect(response.status).toBe(500);
+    expect(setPushPreference).not.toHaveBeenCalled();
+  });
+
+  it('L1 설정이 실패해도 500', async () => {
+    vi.mocked(setPushPreference).mockRejectedValue(
+      new Error('connection refused'),
+    );
+
+    const response = await POST(makeRequest(buildBody()));
+
+    expect(response.status).toBe(500);
+  });
+});
+
+describe('DELETE /api/push/subscribe', () => {
+  it('비로그인이면 401을 반환하고 아무것도 바꾸지 않는다', async () => {
+    vi.mocked(getSessionUser).mockResolvedValue(null);
+
+    const response = await DELETE();
+
+    expect(response.status).toBe(401);
+    expect(setPushPreference).not.toHaveBeenCalled();
+  });
+
+  it('L1 enabled=false만 설정하고 200 — L2 채널은 건드리지 않는다', async () => {
+    const response = await DELETE();
+
+    expect(response.status).toBe(200);
+    expect(setPushPreference).toHaveBeenCalledWith(
+      expect.anything(),
+      USER_ID,
+      false,
+    );
+    expect(upsertPushSubscription).not.toHaveBeenCalled();
+  });
+
+  it('DB 예외면 500', async () => {
+    vi.mocked(setPushPreference).mockRejectedValue(
+      new Error('connection refused'),
+    );
+
+    const response = await DELETE();
+
+    expect(response.status).toBe(500);
+  });
+});

--- a/src/app/api/push/subscribe/route.ts
+++ b/src/app/api/push/subscribe/route.ts
@@ -1,0 +1,122 @@
+/**
+ * 웹 푸시 구독 엔드포인트 (#39, Step 9-b).
+ *
+ * 구독 모델(ADR 008): 구독 의사(L1, 계정 단위)와 배달 채널(L2, 계정×기기)을
+ * 분리한다. 발송(9-c)은 L1 enabled = true인 계정의 L2 채널에만 보낸다.
+ *
+ * POST — 구독 켜기. 호출자: 구독 UI가 PushManager.subscribe() 성공 후
+ *   `PushSubscription.toJSON()` 형태를 보낸다.
+ *   1. 세션에서 user_id 도출 — 구독은 항상 로그인 사용자 소유.
+ *   2. body 검증 (endpoint + keys.p256dh + keys.auth 필수).
+ *   3. L2 채널 UPSERT (user_id, endpoint 충돌 키 — 멱등) + L1 enabled = true.
+ *
+ * DELETE — 구독 끄기. L1 enabled = false만 설정한다 — 어느 기기에서 끄든
+ *   계정 차원에서 꺼진다(전 기기 공유). L2 row와 브라우저 푸시 채널은
+ *   건드리지 않는다: 같은 기기의 다른 계정 채널을 보호하고, 죽은 채널
+ *   정리는 발송 시 410 Gone(9-c)이 담당한다.
+ *
+ * 쓰기는 admin 클라가 아니라 세션 바인딩된 server 클라로 수행해
+ * RLS(user_id = auth.uid())가 소유권을 강제하게 한다.
+ *
+ * 에러 매핑:
+ *   - 401: 비로그인.
+ *   - 400: (POST) body가 JSON이 아니거나 필수 필드 누락.
+ *   - 500: DB 예외.
+ */
+
+import { NextResponse } from 'next/server';
+
+import { getSessionUser } from '@/lib/auth/getSessionUser';
+import { setPushPreference } from '@/lib/supabase/pushPreferencesRepository';
+import {
+  subscriptionToRow,
+  upsertPushSubscription,
+} from '@/lib/supabase/pushSubscriptionsRepository';
+import { getSupabaseServerClient } from '@/lib/supabase/serverClient';
+import type { PushSubscriptionJson } from '@/types/push';
+
+export const dynamic = 'force-dynamic';
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === 'string' && value.length > 0;
+}
+
+/** 수신 body가 PushSubscription.toJSON() 필수 형태를 갖췄는지 검증. */
+function parseSubscription(body: unknown): PushSubscriptionJson | null {
+  if (typeof body !== 'object' || body === null) return null;
+
+  const { endpoint, keys } = body as {
+    endpoint?: unknown;
+    keys?: { p256dh?: unknown; auth?: unknown };
+  };
+
+  if (!isNonEmptyString(endpoint)) return null;
+  if (!isNonEmptyString(keys?.p256dh) || !isNonEmptyString(keys?.auth)) {
+    return null;
+  }
+
+  return { endpoint, keys: { p256dh: keys.p256dh, auth: keys.auth } };
+}
+
+export async function POST(request: Request): Promise<NextResponse> {
+  const user = await getSessionUser();
+  if (!user) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 });
+  }
+
+  const subscription = parseSubscription(body);
+  if (!subscription) {
+    return NextResponse.json(
+      { error: 'endpoint, keys.p256dh, keys.auth are required' },
+      { status: 400 },
+    );
+  }
+
+  try {
+    const client = await getSupabaseServerClient();
+    const row = subscriptionToRow(
+      user.userId,
+      subscription,
+      request.headers.get('user-agent'),
+    );
+    await upsertPushSubscription(client, row);
+    await setPushPreference(client, user.userId, true);
+
+    return NextResponse.json({ ok: true }, { status: 201 });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Unknown error';
+    console.error('[push/subscribe] POST failed:', err);
+    return NextResponse.json(
+      { error: 'Failed to save subscription', message },
+      { status: 500 },
+    );
+  }
+}
+
+export async function DELETE(): Promise<NextResponse> {
+  const user = await getSessionUser();
+  if (!user) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  try {
+    const client = await getSupabaseServerClient();
+    await setPushPreference(client, user.userId, false);
+
+    return NextResponse.json({ ok: true }, { status: 200 });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Unknown error';
+    console.error('[push/subscribe] DELETE failed:', err);
+    return NextResponse.json(
+      { error: 'Failed to disable subscription', message },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/subscribe/page.tsx
+++ b/src/app/subscribe/page.tsx
@@ -2,6 +2,8 @@ import { LoginButtons } from '@/components/auth/LoginButtons';
 import { LogoutButton } from '@/components/auth/LogoutButton';
 import { PushSubscribeButton } from '@/components/push/PushSubscribeButton';
 import { getSessionUser } from '@/lib/auth/getSessionUser';
+import { getPushPreference } from '@/lib/supabase/pushPreferencesRepository';
+import { getSupabaseServerClient } from '@/lib/supabase/serverClient';
 
 /**
  * 알림 구독 페이지 (임시 검증 단계, Step 9-a + 50-b 게이팅).
@@ -15,6 +17,11 @@ import { getSessionUser } from '@/lib/auth/getSessionUser';
 export default async function SubscribePage() {
   const user = await getSessionUser();
 
+  // 계정 구독 상태(L1)는 계정 단위라 어느 기기에서 보든 같다 (ADR 008).
+  const enabled = user
+    ? await getPushPreference(await getSupabaseServerClient(), user.userId)
+    : false;
+
   return (
     <main className="mx-auto max-w-md p-8">
       <h1 className="mb-4 text-xl font-bold">알림 구독 (임시)</h1>
@@ -27,7 +34,7 @@ export default async function SubscribePage() {
             </span>
             <LogoutButton />
           </div>
-          <PushSubscribeButton />
+          <PushSubscribeButton initialEnabled={enabled} />
         </div>
       ) : (
         <div className="flex flex-col gap-3">

--- a/src/components/push/PushSubscribeButton.tsx
+++ b/src/components/push/PushSubscribeButton.tsx
@@ -1,15 +1,32 @@
 'use client';
 
+import { useEffect, useRef, useState } from 'react';
+
 import { usePushSubscription } from '@/hooks/usePushSubscription';
+import {
+  disablePushSubscription,
+  persistPushSubscription,
+} from '@/lib/push/persistPushSubscription';
+
+interface PushSubscribeButtonProps {
+  /** 서버에서 조회한 계정 구독 상태 (L1 enabled) */
+  initialEnabled: boolean;
+}
 
 /**
- * 임시 검증용 구독 버튼 (Step 9-a).
+ * 임시 검증용 구독 토글 (Step 9-a 구독 생성 + 9-b 저장/해제 연결).
  *
- * 9-a의 subscribe 흐름(SW 등록 → 알림 권한 → PushManager.subscribe)이
- * 실제 브라우저에서 동작하는지 눈으로 확인하기 위한 최소 UI다.
+ * - 구독: 브라우저 채널 생성(subscribe) → 서버 저장 + 계정 구독 ON.
+ * - 해제: 계정 구독 OFF만 — 어느 기기에서 끄든 전 기기가 꺼진다 (ADR 008).
+ * - 계정 구독이 켜져 있어도 이 브라우저에 채널이 없으면(다른 기기에서 켠 경우)
+ *   이 기기는 알림을 못 받으므로, 채널 등록 버튼을 따로 노출한다
+ *   (푸시 권한은 브라우저별 개별 — 계정으로 자동 이전 불가).
+ *
  * 본 디자인은 Sprint 2의 화면(구독/목록/상세)이 모두 잡힌 뒤 일괄 작업한다.
  */
-export function PushSubscribeButton() {
+export function PushSubscribeButton({
+  initialEnabled,
+}: PushSubscribeButtonProps) {
   const {
     isSupported,
     permission,
@@ -19,16 +36,100 @@ export function PushSubscribeButton() {
     subscribe,
   } = usePushSubscription();
 
+  const [enabled, setEnabled] = useState(initialEnabled);
+  const [isPending, setIsPending] = useState(false);
+  const [apiError, setApiError] = useState<Error | null>(null);
+
+  // 재동기화(ADR 008): 계정 구독이 켜져 있고 이 브라우저에 채널이 있으면
+  // 현재 계정의 (user, endpoint) row를 멱등 POST로 보장한다. 브라우저 채널은
+  // 계정이 아니라 브라우저에 붙으므로, 채널 존재만으로는 "현재 계정이 이
+  // 기기로 수신 가능"이 보장되지 않는다(공유 브라우저 + 다계정). 키 회전
+  // 치유도 겸한다. 실패는 치명적이지 않아 무시한다 — 다음 방문·구독 액션에서
+  // 재시도된다.
+  const didSyncRef = useRef(false);
+  useEffect(() => {
+    if (didSyncRef.current || !enabled || !subscription) return;
+    didSyncRef.current = true;
+    persistPushSubscription(subscription).catch(() => {});
+  }, [enabled, subscription]);
+
+  const runApiAction = async (action: () => Promise<void>) => {
+    setIsPending(true);
+    setApiError(null);
+    try {
+      await action();
+    } catch (err) {
+      setApiError(err instanceof Error ? err : new Error(String(err)));
+    } finally {
+      setIsPending(false);
+    }
+  };
+
+  // 브라우저 채널 생성 + 서버 저장 + 계정 구독 ON
+  const handleSubscribe = async () => {
+    const next = await subscribe();
+    if (!next) return;
+
+    // persist await 전에 동기적으로 표시 — 대기 중 재동기화 이펙트가
+    // 발화해도(계정 구독이 이미 켜진 경로) 중복 POST하지 않게 한다
+    didSyncRef.current = true;
+    await runApiAction(async () => {
+      await persistPushSubscription(next);
+      setEnabled(true);
+    });
+  };
+
+  // 계정 구독 OFF (L1만 — 브라우저 채널은 보존)
+  const handleDisable = async () => {
+    await runApiAction(async () => {
+      await disablePushSubscription();
+      setEnabled(false);
+    });
+  };
+
+  const isBusy = isSubscribing || isPending;
+
   return (
     <div className="flex flex-col gap-3">
-      <button
-        type="button"
-        onClick={() => void subscribe()}
-        disabled={!isSupported || isSubscribing}
-        className="w-fit rounded bg-blue-600 px-4 py-2 text-white disabled:opacity-50"
-      >
-        {isSubscribing ? '구독 처리 중…' : '알림 구독'}
-      </button>
+      <p className="text-sm">
+        <span className="font-medium">계정 구독 상태: </span>
+        <span className={enabled ? 'text-green-700' : 'text-zinc-600'}>
+          {enabled ? '구독 중' : '꺼짐'}
+        </span>
+      </p>
+
+      {enabled ? (
+        <div className="flex flex-col gap-2">
+          <button
+            type="button"
+            onClick={() => void handleDisable()}
+            disabled={isBusy}
+            className="w-fit rounded bg-zinc-600 px-4 py-2 text-white disabled:opacity-50"
+          >
+            {isPending ? '해제 중…' : '알림 해제 (모든 기기)'}
+          </button>
+
+          {!subscription && (
+            <button
+              type="button"
+              onClick={() => void handleSubscribe()}
+              disabled={!isSupported || isBusy}
+              className="w-fit rounded bg-blue-600 px-4 py-2 text-white disabled:opacity-50"
+            >
+              {isBusy ? '등록 중…' : '이 기기에서도 알림 받기'}
+            </button>
+          )}
+        </div>
+      ) : (
+        <button
+          type="button"
+          onClick={() => void handleSubscribe()}
+          disabled={!isSupported || isBusy}
+          className="w-fit rounded bg-blue-600 px-4 py-2 text-white disabled:opacity-50"
+        >
+          {isBusy ? '구독 처리 중…' : '알림 구독'}
+        </button>
+      )}
 
       <dl className="text-sm">
         <div>
@@ -39,14 +140,17 @@ export function PushSubscribeButton() {
           <dt className="inline font-medium">권한: </dt>
           <dd className="inline">{permission ?? '-'}</dd>
         </div>
+        <div>
+          <dt className="inline font-medium">이 기기 채널: </dt>
+          <dd className="inline break-all">
+            {subscription ? subscription.endpoint : '없음'}
+          </dd>
+        </div>
       </dl>
 
       {error && <p className="text-sm text-red-600">오류: {error.message}</p>}
-
-      {subscription && (
-        <p className="text-sm break-all text-green-700">
-          구독 생성됨 — endpoint: {subscription.endpoint}
-        </p>
+      {apiError && (
+        <p className="text-sm text-red-600">오류: {apiError.message}</p>
       )}
     </div>
   );

--- a/src/lib/push/persistPushSubscription.test.ts
+++ b/src/lib/push/persistPushSubscription.test.ts
@@ -1,0 +1,84 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  disablePushSubscription,
+  persistPushSubscription,
+} from './persistPushSubscription';
+
+const SUBSCRIPTION_JSON = {
+  endpoint: 'https://fcm.googleapis.com/fcm/send/abc123',
+  expirationTime: null,
+  keys: { p256dh: 'p256dh-key', auth: 'auth-secret' },
+};
+
+function buildSubscription(): PushSubscription {
+  return {
+    toJSON: () => SUBSCRIPTION_JSON,
+  } as unknown as PushSubscription;
+}
+
+const fetchMock = vi.fn();
+
+beforeEach(() => {
+  vi.stubGlobal('fetch', fetchMock);
+  fetchMock.mockReset();
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('persistPushSubscription', () => {
+  it('toJSON() 결과를 POST /api/push/subscribe로 전송한다', async () => {
+    fetchMock.mockResolvedValue(new Response(null, { status: 201 }));
+
+    await persistPushSubscription(buildSubscription());
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe('/api/push/subscribe');
+    expect(init.method).toBe('POST');
+    expect(JSON.parse(init.body)).toEqual(SUBSCRIPTION_JSON);
+  });
+
+  it('실패 응답이면 상태 코드와 서버 error 메시지를 포함해 throw한다', async () => {
+    fetchMock.mockResolvedValue(
+      Response.json({ error: 'Unauthorized' }, { status: 401 }),
+    );
+
+    await expect(persistPushSubscription(buildSubscription())).rejects.toThrow(
+      /구독 저장 실패 \(401\): Unauthorized/,
+    );
+  });
+
+  it('실패 응답 body가 JSON이 아니어도 상태 코드로 throw한다', async () => {
+    fetchMock.mockResolvedValue(new Response('oops', { status: 500 }));
+
+    await expect(persistPushSubscription(buildSubscription())).rejects.toThrow(
+      /구독 저장 실패 \(500\)/,
+    );
+  });
+});
+
+describe('disablePushSubscription', () => {
+  it('DELETE /api/push/subscribe를 호출한다', async () => {
+    fetchMock.mockResolvedValue(new Response(null, { status: 200 }));
+
+    await disablePushSubscription();
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe('/api/push/subscribe');
+    expect(init.method).toBe('DELETE');
+  });
+
+  it('실패 응답이면 상태 코드와 서버 error 메시지를 포함해 throw한다', async () => {
+    fetchMock.mockResolvedValue(
+      Response.json({ error: 'Unauthorized' }, { status: 401 }),
+    );
+
+    await expect(disablePushSubscription()).rejects.toThrow(
+      /구독 해제 실패 \(401\): Unauthorized/,
+    );
+  });
+});

--- a/src/lib/push/persistPushSubscription.ts
+++ b/src/lib/push/persistPushSubscription.ts
@@ -1,0 +1,47 @@
+/**
+ * 웹 푸시 구독 API(9-b) 클라이언트 헬퍼.
+ *
+ * usePushSubscription 훅은 브라우저 구독(배달 채널) 생성까지만 책임지므로(9-a),
+ * 서버 저장/해제는 이 모듈이 담당한다. 실패는 throw로 표면화해
+ * 호출 측 UI가 상태로 노출하게 한다.
+ */
+
+const SUBSCRIBE_ENDPOINT = '/api/push/subscribe';
+
+/** 생성된 브라우저 구독을 서버에 저장하고 계정 구독을 켠다 (POST). */
+export async function persistPushSubscription(
+  subscription: PushSubscription,
+): Promise<void> {
+  const response = await fetch(SUBSCRIBE_ENDPOINT, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(subscription.toJSON()),
+  });
+
+  if (!response.ok) {
+    const message = await extractErrorMessage(response);
+    throw new Error(`구독 저장 실패 (${response.status}): ${message}`);
+  }
+}
+
+/**
+ * 계정 구독을 끈다 (DELETE) — 어느 기기에서 호출하든 계정 차원에서 꺼진다.
+ * 브라우저 쪽 배달 채널은 건드리지 않는다 (ADR 008).
+ */
+export async function disablePushSubscription(): Promise<void> {
+  const response = await fetch(SUBSCRIBE_ENDPOINT, { method: 'DELETE' });
+
+  if (!response.ok) {
+    const message = await extractErrorMessage(response);
+    throw new Error(`구독 해제 실패 (${response.status}): ${message}`);
+  }
+}
+
+async function extractErrorMessage(response: Response): Promise<string> {
+  try {
+    const body = (await response.json()) as { error?: unknown };
+    return typeof body.error === 'string' ? body.error : 'Unknown error';
+  } catch {
+    return 'Unknown error';
+  }
+}

--- a/src/lib/supabase/pushPreferencesRepository.test.ts
+++ b/src/lib/supabase/pushPreferencesRepository.test.ts
@@ -1,0 +1,95 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  getPushPreference,
+  setPushPreference,
+} from './pushPreferencesRepository';
+
+const USER_ID = 'b7e6a4c2-0000-4000-8000-000000000001';
+
+/**
+ * Supabase 메서드 체이닝 mock 헬퍼.
+ * - setPushPreference: `from().upsert()` — Promise 반환.
+ * - getPushPreference: `from().select().eq().maybeSingle()` — 종단만 Promise.
+ */
+function createMockClient(result: {
+  data?: { enabled: boolean } | null;
+  error: { message: string } | null;
+}) {
+  const upsert = vi.fn().mockResolvedValue(result);
+  const maybeSingle = vi.fn().mockResolvedValue(result);
+  const eq = vi.fn().mockReturnValue({ maybeSingle });
+  const select = vi.fn().mockReturnValue({ eq });
+  const from = vi.fn().mockReturnValue({ upsert, select });
+  const client = { from } as unknown as SupabaseClient;
+  return { client, from, upsert, select, eq };
+}
+
+describe('setPushPreference', () => {
+  it('push_preferences 테이블에 user_id 기준 UPSERT를 호출한다', async () => {
+    const { client, from, upsert } = createMockClient({ error: null });
+
+    await setPushPreference(client, USER_ID, true);
+
+    expect(from).toHaveBeenCalledWith('push_preferences');
+    expect(upsert).toHaveBeenCalledWith(
+      { user_id: USER_ID, enabled: true },
+      { onConflict: 'user_id' },
+    );
+  });
+
+  it('enabled = false(구독 해제)도 같은 UPSERT 경로를 쓴다', async () => {
+    const { client, upsert } = createMockClient({ error: null });
+
+    await setPushPreference(client, USER_ID, false);
+
+    expect(upsert).toHaveBeenCalledWith(
+      { user_id: USER_ID, enabled: false },
+      { onConflict: 'user_id' },
+    );
+  });
+
+  it('Supabase가 에러를 반환하면 throw로 표면화한다', async () => {
+    const { client } = createMockClient({
+      error: { message: 'connection refused' },
+    });
+
+    await expect(setPushPreference(client, USER_ID, true)).rejects.toThrow(
+      /Failed to set push preference: connection refused/,
+    );
+  });
+});
+
+describe('getPushPreference', () => {
+  it('본인 row의 enabled 값을 반환한다', async () => {
+    const { client, eq } = createMockClient({
+      data: { enabled: true },
+      error: null,
+    });
+
+    const enabled = await getPushPreference(client, USER_ID);
+
+    expect(enabled).toBe(true);
+    expect(eq).toHaveBeenCalledWith('user_id', USER_ID);
+  });
+
+  it('row가 없으면(구독한 적 없음) false를 반환한다', async () => {
+    const { client } = createMockClient({ data: null, error: null });
+
+    const enabled = await getPushPreference(client, USER_ID);
+
+    expect(enabled).toBe(false);
+  });
+
+  it('Supabase가 에러를 반환하면 throw로 표면화한다', async () => {
+    const { client } = createMockClient({
+      data: null,
+      error: { message: 'connection refused' },
+    });
+
+    await expect(getPushPreference(client, USER_ID)).rejects.toThrow(
+      /Failed to get push preference: connection refused/,
+    );
+  });
+});

--- a/src/lib/supabase/pushPreferencesRepository.ts
+++ b/src/lib/supabase/pushPreferencesRepository.ts
@@ -1,0 +1,57 @@
+/**
+ * push_preferences(L1 구독 의사) 테이블 리포지터리.
+ *
+ * 계정당 1 row(user_id UNIQUE)로 "이 계정이 알림을 원한다"를 표현한다.
+ * 어느 기기에서 토글하든 계정 차원에서 켜지고 꺼진다 — 전 기기 공유
+ * (ADR 008). 발송(9-c)은 enabled = true인 계정의 채널(L2)에만 보낸다.
+ *
+ * 클라이언트는 인자로 받아 테스트에서 모킹하기 쉽게 한다.
+ * 호출자는 세션 바인딩된 server 클라이언트를 전달해 RLS가
+ * 소유권(user_id = auth.uid())을 강제하게 한다.
+ */
+
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+const TABLE = 'push_preferences';
+
+/**
+ * 계정의 구독 의사를 설정한다. row가 없으면 만들고, 있으면 enabled만 갱신
+ * (user_id 충돌 키 UPSERT — 멱등).
+ *
+ * Supabase 에러는 throw로 표면화 → 호출자(Route Handler)에서 5xx로 매핑.
+ */
+export async function setPushPreference(
+  client: SupabaseClient,
+  userId: string,
+  enabled: boolean,
+): Promise<void> {
+  const { error } = await client
+    .from(TABLE)
+    .upsert({ user_id: userId, enabled }, { onConflict: 'user_id' });
+
+  if (error) {
+    throw new Error(`Failed to set push preference: ${error.message}`);
+  }
+}
+
+/**
+ * 계정의 구독 의사를 조회한다. row가 없으면(한 번도 구독한 적 없음) false.
+ *
+ * 구독 페이지가 현재 상태를 노출할 때 쓴다.
+ */
+export async function getPushPreference(
+  client: SupabaseClient,
+  userId: string,
+): Promise<boolean> {
+  const { data, error } = await client
+    .from(TABLE)
+    .select('enabled')
+    .eq('user_id', userId)
+    .maybeSingle();
+
+  if (error) {
+    throw new Error(`Failed to get push preference: ${error.message}`);
+  }
+
+  return data?.enabled === true;
+}

--- a/src/lib/supabase/pushSubscriptionsRepository.test.ts
+++ b/src/lib/supabase/pushSubscriptionsRepository.test.ts
@@ -1,0 +1,78 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { describe, expect, it, vi } from 'vitest';
+
+import type { PushSubscriptionJson } from '@/types/push';
+
+import {
+  subscriptionToRow,
+  upsertPushSubscription,
+} from './pushSubscriptionsRepository';
+
+const USER_ID = 'b7e6a4c2-0000-4000-8000-000000000001';
+
+function buildSubscription(
+  overrides: Partial<PushSubscriptionJson> = {},
+): PushSubscriptionJson {
+  return {
+    endpoint: 'https://fcm.googleapis.com/fcm/send/abc123',
+    keys: { p256dh: 'p256dh-key', auth: 'auth-secret' },
+    ...overrides,
+  };
+}
+
+/**
+ * Supabase 메서드 체이닝(`from().upsert()`)을 위한 mock 헬퍼.
+ * - upsert는 `await` 대상이므로 Promise를 반환.
+ */
+function createMockClient(result: { error: { message: string } | null }) {
+  const upsert = vi.fn().mockResolvedValue(result);
+  const from = vi.fn().mockReturnValue({ upsert });
+  const client = { from } as unknown as SupabaseClient;
+  return { client, from, upsert };
+}
+
+describe('subscriptionToRow', () => {
+  it('userId + PushSubscription JSON을 snake_case row로 매핑한다', () => {
+    const row = subscriptionToRow(USER_ID, buildSubscription(), 'Mozilla/5.0');
+
+    expect(row).toEqual({
+      user_id: USER_ID,
+      endpoint: 'https://fcm.googleapis.com/fcm/send/abc123',
+      p256dh: 'p256dh-key',
+      auth: 'auth-secret',
+      user_agent: 'Mozilla/5.0',
+    });
+  });
+
+  it('userAgent가 없으면 null을 그대로 전달한다', () => {
+    const row = subscriptionToRow(USER_ID, buildSubscription(), null);
+
+    expect(row.user_agent).toBeNull();
+  });
+});
+
+describe('upsertPushSubscription', () => {
+  it('push_subscriptions 테이블에 (user_id, endpoint) 기준 UPSERT를 호출한다', async () => {
+    const { client, from, upsert } = createMockClient({ error: null });
+    const row = subscriptionToRow(USER_ID, buildSubscription(), null);
+
+    await upsertPushSubscription(client, row);
+
+    expect(from).toHaveBeenCalledWith('push_subscriptions');
+    expect(upsert).toHaveBeenCalledTimes(1);
+    expect(upsert).toHaveBeenCalledWith(row, {
+      onConflict: 'user_id,endpoint',
+    });
+  });
+
+  it('Supabase가 에러를 반환하면 throw로 표면화한다', async () => {
+    const { client } = createMockClient({
+      error: { message: 'connection refused' },
+    });
+    const row = subscriptionToRow(USER_ID, buildSubscription(), null);
+
+    await expect(upsertPushSubscription(client, row)).rejects.toThrow(
+      /Failed to upsert push subscription: connection refused/,
+    );
+  });
+});

--- a/src/lib/supabase/pushSubscriptionsRepository.ts
+++ b/src/lib/supabase/pushSubscriptionsRepository.ts
@@ -1,0 +1,63 @@
+/**
+ * push_subscriptions(L2 배달 채널) 테이블 UPSERT 리포지터리 패턴.
+ *
+ * - 입력: 세션에서 도출한 userId + 브라우저 PushSubscription JSON.
+ * - 동작: UNIQUE(user_id, endpoint)를 키로 UPSERT — 같은 기기의 재구독은
+ *   멱등 갱신되고, 같은 기기를 쓰는 다른 계정의 채널과는 충돌하지 않는다
+ *   (ADR 008: 계정별 독립).
+ * - 클라이언트는 인자로 받아 테스트에서 모킹하기 쉽게 한다.
+ *   호출자는 세션 바인딩된 server 클라이언트를 전달해 RLS가
+ *   소유권(user_id = auth.uid())을 강제하게 한다.
+ */
+
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+import type { PushSubscriptionJson } from '@/types/push';
+
+const TABLE = 'push_subscriptions';
+
+/** Supabase에 UPSERT로 전달하는 row 형태 (snake_case). */
+export interface PushSubscriptionInsertRow {
+  user_id: string;
+  endpoint: string;
+  p256dh: string;
+  auth: string;
+  user_agent: string | null;
+}
+
+/**
+ * PushSubscription JSON + 소유자 → DB row (snake_case).
+ * 순수 함수. 단위 테스트로 매핑 정확성을 검증한다.
+ */
+export function subscriptionToRow(
+  userId: string,
+  subscription: PushSubscriptionJson,
+  userAgent: string | null,
+): PushSubscriptionInsertRow {
+  return {
+    user_id: userId,
+    endpoint: subscription.endpoint,
+    p256dh: subscription.keys.p256dh,
+    auth: subscription.keys.auth,
+    user_agent: userAgent,
+  };
+}
+
+/**
+ * 배달 채널 row를 push_subscriptions 테이블에 UPSERT.
+ *
+ * - (user_id, endpoint)를 충돌 키로 사용 (마이그레이션의 복합 UNIQUE와 일치).
+ * - Supabase 에러는 throw로 표면화 → 호출자(Route Handler)에서 5xx로 매핑.
+ */
+export async function upsertPushSubscription(
+  client: SupabaseClient,
+  row: PushSubscriptionInsertRow,
+): Promise<void> {
+  const { error } = await client
+    .from(TABLE)
+    .upsert(row, { onConflict: 'user_id,endpoint' });
+
+  if (error) {
+    throw new Error(`Failed to upsert push subscription: ${error.message}`);
+  }
+}

--- a/src/types/push.ts
+++ b/src/types/push.ts
@@ -1,0 +1,17 @@
+/**
+ * 웹 푸시 구독 공유 타입.
+ *
+ * 브라우저 `PushSubscription.toJSON()`이 만드는 형태 중 발송(9-c)에
+ * 필요한 값만 담는다 — endpoint + keys(p256dh, auth).
+ * `expirationTime`은 저장하지 않는다 (ADR 008: 만료 정리는 발송 시 410 Gone).
+ */
+export interface PushSubscriptionJson {
+  /** 푸시 서비스가 구독마다 발급하는 고유 URL. 기기 식별 키 */
+  endpoint: string;
+  keys: {
+    /** 메시지 암호화용 클라이언트 공개키 */
+    p256dh: string;
+    /** 메시지 인증 시크릿 */
+    auth: string;
+  };
+}

--- a/supabase/migrations/00002_create_push_subscriptions.sql
+++ b/supabase/migrations/00002_create_push_subscriptions.sql
@@ -1,0 +1,76 @@
+-- 웹 푸시 구독 (ADR 008: 구독 의사 L1 / 배달 채널 L2 분리)
+--
+-- L1 push_preferences: "이 계정이 알림을 원한다" — 계정당 1 row.
+--   어느 기기에서 끄든 계정 차원에서 꺼진다(전 기기 공유 토글).
+--   Sprint 3의 지역구·유형 필터 조건이 이 테이블에 붙는다.
+-- L2 push_subscriptions: endpoint + keys — (계정, 기기) 단위 배달 채널.
+--   UNIQUE(user_id, endpoint)로 같은 기기를 여러 계정이 독립적으로 쓸 수 있다
+--   (endpoint 단독 UNIQUE였다면 계정 간 소유권 충돌이 생긴다).
+
+-- L1: 계정 단위 구독 의사
+CREATE TABLE push_preferences (
+  id          BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+  user_id     UUID NOT NULL UNIQUE REFERENCES auth.users (id) ON DELETE CASCADE,
+  enabled     BOOLEAN NOT NULL DEFAULT true,
+  created_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at  TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- L2: (계정, 기기) 단위 배달 채널
+CREATE TABLE push_subscriptions (
+  id          BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+  user_id     UUID NOT NULL REFERENCES auth.users (id) ON DELETE CASCADE,
+  endpoint    TEXT NOT NULL,
+  p256dh      TEXT NOT NULL,
+  auth        TEXT NOT NULL,
+  user_agent  TEXT,
+  created_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+  UNIQUE (user_id, endpoint)
+);
+
+-- 발송(9-c)의 사용자별 채널 조회(WHERE user_id = ?)와 FK 참조 확인은
+-- UNIQUE(user_id, endpoint)가 만든 복합 인덱스의 선두 컬럼이 커버하므로
+-- (leftmost prefix) user_id 단독 인덱스는 두지 않는다.
+
+-- updated_at 자동 갱신 (00001의 update_updated_at() 재사용)
+CREATE TRIGGER push_preferences_updated_at
+  BEFORE UPDATE ON push_preferences
+  FOR EACH ROW EXECUTE FUNCTION update_updated_at();
+
+CREATE TRIGGER push_subscriptions_updated_at
+  BEFORE UPDATE ON push_subscriptions
+  FOR EACH ROW EXECUTE FUNCTION update_updated_at();
+
+-- RLS: 사용자 소유 데이터이므로 본인 row만 접근 (ADR 008).
+-- UPDATE 정책은 UPSERT가 충돌 시 내부적으로 UPDATE를 실행하기 때문에 필요하다
+-- (없으면 재구독 키 갱신·enabled 토글이 실패한다).
+ALTER TABLE push_preferences ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY push_preferences_select_own ON push_preferences
+  FOR SELECT USING (user_id = (SELECT auth.uid()));
+
+CREATE POLICY push_preferences_insert_own ON push_preferences
+  FOR INSERT WITH CHECK (user_id = (SELECT auth.uid()));
+
+CREATE POLICY push_preferences_update_own ON push_preferences
+  FOR UPDATE USING (user_id = (SELECT auth.uid()))
+  WITH CHECK (user_id = (SELECT auth.uid()));
+
+CREATE POLICY push_preferences_delete_own ON push_preferences
+  FOR DELETE USING (user_id = (SELECT auth.uid()));
+
+ALTER TABLE push_subscriptions ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY push_subscriptions_select_own ON push_subscriptions
+  FOR SELECT USING (user_id = (SELECT auth.uid()));
+
+CREATE POLICY push_subscriptions_insert_own ON push_subscriptions
+  FOR INSERT WITH CHECK (user_id = (SELECT auth.uid()));
+
+CREATE POLICY push_subscriptions_update_own ON push_subscriptions
+  FOR UPDATE USING (user_id = (SELECT auth.uid()))
+  WITH CHECK (user_id = (SELECT auth.uid()));
+
+CREATE POLICY push_subscriptions_delete_own ON push_subscriptions
+  FOR DELETE USING (user_id = (SELECT auth.uid()));


### PR DESCRIPTION
## Summary

웹 푸시 파이프라인(#39)의 Step 9-b — 구독 저장 API + DB 스키마.

구독 상태를 **계정의 속성**으로 모델링합니다: 구독 의사(L1, 계정 단위)와 배달 채널(L2, 계정×기기)을 분리해, 같은 기기의 계정 간 독립(상황 1)과 같은 계정의 기기 간 공유(상황 2)를 모두 충족합니다. 모델·근거는 ADR 008(이 PR에서 재작성).

## 주요 변경 사항

### 1. DB 스키마 (`00002_create_push_subscriptions.sql`)

- L1 `push_preferences`: 계정당 1 row(`user_id` UNIQUE) + `enabled` — 전 기기 공유 토글, Sprint 3 필터가 붙을 자리
- L2 `push_subscriptions`: endpoint + keys, **`UNIQUE(user_id, endpoint)`** — 같은 기기의 {A,E}·{B,E} 공존(계정 간 소유권 충돌 구조적 제거)
- 두 테이블 모두 RLS로 본인 row만 접근 (update 정책 포함 — UPSERT 충돌 시 내부 UPDATE 때문에 필수)
- user_id 단독 인덱스는 두지 않음 — 복합 UNIQUE 인덱스의 leftmost prefix가 발송 조회·FK 확인을 커버

### 2. API (`/api/push/subscribe`)

- `POST` = 구독 켜기: 세션에서 user_id 도출(비로그인 401), body 검증(400), L2 UPSERT + L1 ON → 201, DB 예외 500
- `DELETE` = 구독 끄기: L1 `enabled=false`만 — 어느 기기에서 끄든 계정 차원 OFF. L2·브라우저 채널은 보존(죽은 채널은 9-c의 410 Gone이 정리)
- 쓰기는 세션 바인딩 server 클라로 수행 — RLS가 소유권 강제

### 3. UI 연결 (임시 검증 UI)

- `/subscribe` 서버 컴포넌트가 L1 상태 조회 → 구독/해제 토글
- 계정 구독 ON + 이 브라우저 채널 없음(다른 기기에서 켠 경우) → "이 기기에서도 알림 받기" 별도 노출
- 마운트 재동기화: 멱등 POST 1회로 현재 계정의 (user, endpoint) row 보장 (공유 브라우저에서 타 계정 채널 오판 갭 차단, 키 회전 치유 겸용)

### 4. ADR 008 재작성

- 요구사항(상황 1·2) + 웹 푸시 물리 제약 2개 명시
- 폐기 선택지 4개 기록 (직전 endpoint 단독 UNIQUE + 409 모델 포함 — 상황 1·2 모두 위반)

## 참고 사항

- 관련 이슈: #39 (Step 9-b). 테스트 132개 통과(신규 29개), typecheck/lint 클린
- **마이그레이션 적용 필요**: 머지 후 `00002`를 Supabase에 적용해야 실제 저장이 동작합니다
- 실브라우저 E2E(로그인 → 구독 → row 확인)는 외부 OAuth 설정(#50 선결) + 마이그레이션 적용 후 9-d에서
- 발송·410 Gone 정리는 9-c 범위

🤖 Generated with [Claude Code](https://claude.com/claude-code)