### PR TITLE
fix: 마이그레이션 GRANT 명시 + RLS 학습 문서 보강 + HANDOFF 갱신 (#39)

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -17,6 +17,8 @@ Sprint 2 1번 작업(웹 푸시 파이프라인, #39)을 Step(9-a~d)으로 쪼�
 
 **9-c 완료·머지**(PR #58, 2026-07-20): 크롤 신규 감지 → 웹 푸시 발송 연결. `pushChannelsRepository`(L1 `enabled` 계정의 L2 채널 조회 + 만료 endpoint 삭제) + `buildNotificationPayload`(1건은 공고 제목 + soco `view.do` URL, N건은 집계 알림 — 내부 상세 페이지가 생기면 이 모듈의 URL 빌더만 교체) + `webPushClient`(`web-push` 어댑터, 실패를 statusCode 포함 결과 값으로 정규화) + `notificationService`(채널별 격리 발송 + `410`/`404` endpoint 정리 + `{sent, expired, failed}` 집계). `/api/cron/crawl`은 저장·`lastBoardId` 갱신 **완료 후** 발송하고, 발송 실패는 500이 아닌 응답 `push.error`로만 표면화(500이면 호출자 재시도 → 같은 공고 중복 발송이므로 유실을 수용 — ADR 008). 학습 문서: 웹 푸시 정리 **작성 완료**(`docs/learning/step9-web-push.md`).
 
+**외부 선결 완료 + 실환경 수동 검증 성공**(2026-07-20): 외부 선결 3종(OAuth 콘솔·provider 설정 / 00002 마이그레이션 적용 / VAPID env 로컬·Vercel 주입) 모두 완료. 카카오 이메일(account_email)은 **비즈 앱 전용 권한**이라 동의항목에서 제외하고 Supabase Kakao provider의 **"Allow users without an email"** 로 대응 — 파이프라인은 email이 아닌 `user_id` 기준이라 영향 없음(이메일 알림 도입 시 카카오 사용자는 수신 주소 부재 유의). 검증: 로컬에서 구글 로그인 → 구독 토글 ON(L1·L2 row 생성 확인) → `last_board_id` 하향 후 크롤 트리거 → `push: {sent: 1}` + Chrome 알림 수신까지 **MVP 핵심 경로 관통 확인**. 이 과정에서 두 이슈를 밟고 해소: ① Supabase Redirect URLs를 경로 고정형에서 **globstar(`/**`)로 교체**(쿼리 파라미터 붙는 redirectTo가 매칭 실패 → Site URL 루트로 낙하하던 문제), ② **Supabase의 새 테이블 자동 GRANT 폐기**(2026-05-30~)로 `permission denied for table` — GRANT 명시로 해소, 마이그레이션 파일 백필 + RLS 학습 문서 §2 보강(이 커밋).
+
 ### ✅ 해소됨 — 크롤 파이프라인 동결 (Issue #42, 2026-06-18)
 
 매시간 HTTP 500으로 동결됐던 크롤 파이프라인을 PR #45로 해소(프로덕션 500→200, DB 저장 검증). 근본 원인(boardId가 여러 게시판이 공유하는 전역 시퀀스 → gap-fill이 타 게시판 불량 row를 끌어와 배치 upsert 전체 실패)과 수정(gap-fill 폐기 → 목록 기반 크롤 전환)은 **ADR 007** 및 `docs/troubleshooting/2026-06-09-cron-bootstrap-catch-up.md`에 상세.
@@ -50,15 +52,13 @@ Sprint 2 1번 작업(웹 푸시 파이프라인, #39)을 Step(9-a~d)으로 쪼�
 
 ### 다음 할 일 — Sprint 2 (PROJECT_PLAN 4-1 참조)
 
-웹 푸시 발송(9-c: PR #58)까지 **머지 완료** — #39의 코드 경로(구독→저장→발송)가 전부 연결됐다 → 다음은 **9-d**. 단, 9-d는 실환경 E2E이므로 아래 외부 선결이 **선행 조건**이다(이전 Step들과 달리 미설정 시 진행 불가).
-
-- **외부 선결(#50 로그인 실제 E2E 전제, 사용자 작업)**: Supabase 대시보드 Google·Kakao provider 활성화 + client_id/secret + redirect allow-list / 구글·카카오 콘솔 OAuth 앱 등록 / env `NEXT_PUBLIC_SUPABASE_URL`·`NEXT_PUBLIC_SUPABASE_ANON_KEY` 주입(로컬 + Vercel).
-- **외부 선결(9-b 실동작 전제, 사용자 작업)**: `supabase/migrations/00002_create_push_subscriptions.sql`을 Supabase에 적용(대시보드 SQL Editor 또는 `supabase db push`).
-- **외부 선결(9-c 실발송 전제, 사용자 작업)**: VAPID 키 쌍 생성(`npx web-push generate-vapid-keys`) 후 env `NEXT_PUBLIC_VAPID_PUBLIC_KEY`·`VAPID_PRIVATE_KEY`·`VAPID_SUBJECT` 주입(로컬 + Vercel). 키 쌍은 로테이션하면 기존 구독이 전부 무효가 되므로 한 번 만들면 유지(`learning/step9-web-push` §2).
+웹 푸시 발송(9-c: PR #58) 머지 + **외부 선결 3종·실환경 수동 검증까지 완료**(위 문단) → **9-d 착수 조건 충족**. 프로덕션도 VAPID env 주입 완료로 매시간 GHA cron이 실운영 발송을 수행하는 상태다.
 
 웹 푸시 파이프라인 (#39) 남은 Step:
 
-- 9-d (다음): Playwright E2E (로그인 → 구독 → 신규 공고 → 알림 수신). 위 외부 선결 3종 완료 후 착수.
+- 9-d (다음): Playwright E2E (로그인 → 구독 → 신규 공고 → 알림 수신). 수동으로 검증한 경로의 자동화.
+
+운영 참고: VAPID 키 쌍은 로테이션하면 기존 구독이 전부 무효가 되므로 한 번 만들면 유지한다(`learning/step9-web-push` §2).
 
 **9-a 머지 코드**: `usePushSubscription` 훅·`urlBase64ToUint8Array`·`sw.js`는 인증과 분리돼 무변경 재사용. `/subscribe` 게이팅은 **50-b에서 완료**(비로그인 시 로그인 유도, 로그인 시 구독 UI 노출).
 

--- a/docs/learning/step9b-supabase-rls.md
+++ b/docs/learning/step9b-supabase-rls.md
@@ -1,6 +1,6 @@
 # Supabase RLS — 소유권을 DB가 강제하게 만드는 법
 
-사용자 소유 데이터(구독, 설정, 북마크 …)를 저장할 때 "내 row만 읽고 쓸 수 있다"를 **애플리케이션 코드가 아니라 DB가** 강제하게 만드는 게 RLS(Row Level Security)다. 이 문서는 RLS를 처음 실전 적용하며 확인한 **어느 프로젝트에나 가져갈 수 있는 패턴 5가지**를 추린다. 청안 고유 결정(어떤 테이블에 어떤 정책을 붙였나, L1/L2 분리 모델)은 ADR 008 소관이다.
+사용자 소유 데이터(구독, 설정, 북마크 …)를 저장할 때 "내 row만 읽고 쓸 수 있다"를 **애플리케이션 코드가 아니라 DB가** 강제하게 만드는 게 RLS(Row Level Security)다. 이 문서는 RLS를 처음 실전 적용하며 확인한 **어느 프로젝트에나 가져갈 수 있는 패턴들**을 추린다. 청안 고유 결정(어떤 테이블에 어떤 정책을 붙였나, L1/L2 분리 모델)은 ADR 008 소관이다.
 
 ---
 
@@ -17,7 +17,39 @@ RLS 정책:    DB가 모든 쿼리에 자동 적용 → 앱 코드가 실수해�
 
 ---
 
-## 2. 정책의 해부 — USING과 WITH CHECK는 검사 시점이 다르다
+## 2. GRANT — RLS보다 한 층 아래에 문이 하나 더 있다
+
+RLS는 접근 제어의 **두 번째** 층이다. 그 아래에 테이블 레벨 권한(GRANT)이 먼저 있다:
+
+| 층        | 단위 | 통과 못 하면                                      |
+| --------- | ---- | ------------------------------------------------- |
+| 1층 GRANT | role | **명시적 에러** `permission denied for table ...` |
+| 2층 RLS   | row  | 조용히 "없는 row" (§1)                            |
+
+증상이 서로 달라서 진단 포인트가 된다 — **"permission denied for table"은 RLS 거부가 아니라 GRANT 부재**다. RLS 정책을 아무리 들여다봐도 원인이 안 나온다.
+
+과거 Supabase는 새 테이블에 `anon`/`authenticated`/`service_role` GRANT를 자동 부여해서 이 층을 의식할 일이 없었지만, **2026-05-30부터 신규 프로젝트에서 자동 노출을 기본 폐기**했고 기존 프로젝트도 2026-10-30부터 강제된다(보안상 opt-in으로 전환). 이제 마이그레이션에 GRANT를 명시하는 것이 필수다:
+
+```sql
+-- "GRANT로 열고 RLS로 잠근다" — Supabase 표준 구성
+GRANT SELECT, INSERT, UPDATE, DELETE ON my_table
+  TO anon, authenticated, service_role;
+ALTER TABLE my_table ENABLE ROW LEVEL SECURITY;
+CREATE POLICY ...;
+```
+
+GRANT를 열어도 row 접근은 여전히 RLS가 통제하므로 보안이 약해지지 않는다. 현재 권한 상태 진단은:
+
+```sql
+SELECT grantee, privilege_type FROM information_schema.role_table_grants
+WHERE table_name = 'my_table';
+```
+
+실제로 9-c 실환경 검증에서 이 문제를 밟았다 — 정책 8개가 전부 정상인데 `/subscribe`가 `permission denied for table push_preferences`로 죽었고, 원인은 마이그레이션(GRANT 미명시)이 정책 변경 이후 시점에 적용된 것이었다.
+
+---
+
+## 3. 정책의 해부 — USING과 WITH CHECK는 검사 시점이 다르다
 
 정책마다 조건식이 두 종류인데, **무엇을 검사하느냐**가 다르다:
 
@@ -47,7 +79,7 @@ UPDATE에서 `WITH CHECK`를 생략하면 **`USING`이 WITH CHECK 역할까지 �
 
 ---
 
-## 3. 함정 — UPSERT는 INSERT 정책만으로는 안 된다
+## 4. 함정 — UPSERT는 INSERT 정책만으로는 안 된다
 
 이번에 직접 밟은 함정. UPSERT(`INSERT ... ON CONFLICT DO UPDATE`)는 충돌이 없으면 INSERT지만, **충돌이 나면 내부적으로 UPDATE를 실행**한다. 즉:
 
@@ -61,7 +93,7 @@ INSERT 정책만 있으면 **최초 저장은 성공하고 두 번째부터 실�
 
 ---
 
-## 4. 어떤 클라이언트로 쓰느냐가 곧 보안 모델이다
+## 5. 어떤 클라이언트로 쓰느냐가 곧 보안 모델이다
 
 Supabase 클라이언트는 쓰는 키에 따라 RLS 적용 여부가 갈린다:
 
@@ -76,7 +108,7 @@ Supabase 클라이언트는 쓰는 키에 따라 RLS 적용 여부가 갈린다:
 
 ---
 
-## 5. 성능 습관 — `auth.uid()`는 `(SELECT auth.uid())`로 감싼다
+## 6. 성능 습관 — `auth.uid()`는 `(SELECT auth.uid())`로 감싼다
 
 정책 조건에 함수를 직접 쓰면 **row마다 재평가**될 수 있다. 서브쿼리로 감싸면 PostgreSQL이 initPlan으로 **쿼리당 1회 평가 후 캐시**한다:
 
@@ -98,7 +130,7 @@ RLS와 직접 관련은 없지만 같은 마이그레이션에서 배운 것: `U
 
 ---
 
-## 6. 테스트 관점
+## 7. 테스트 관점
 
 RLS 정책 자체는 단위 테스트로 검증할 수 없다(정책은 DB에 산다). 역할 분담:
 
@@ -108,9 +140,10 @@ RLS 정책 자체는 단위 테스트로 검증할 수 없다(정책은 DB에 �
 
 ---
 
-## 7. 참고
+## 8. 참고
 
 - Supabase RLS 가이드: https://supabase.com/docs/guides/database/postgres/row-level-security
+- Supabase 자동 노출 폐기 공지 (GRANT 명시 필수화): https://supabase.com/changelog/45329-breaking-change-tables-not-exposed-to-data-and-graphql-api-automatically
 - PostgreSQL CREATE POLICY: https://www.postgresql.org/docs/current/sql-createpolicy.html
 - RLS 성능 권장사항 (`(SELECT auth.uid())` 패턴): https://supabase.com/docs/guides/troubleshooting/rls-performance-and-best-practices-Z5Jjwv
 - PostgreSQL 복합 인덱스와 leftmost prefix: https://www.postgresql.org/docs/current/indexes-multicolumn.html

--- a/supabase/migrations/00002_create_push_subscriptions.sql
+++ b/supabase/migrations/00002_create_push_subscriptions.sql
@@ -33,6 +33,15 @@ CREATE TABLE push_subscriptions (
 -- UNIQUE(user_id, endpoint)가 만든 복합 인덱스의 선두 컬럼이 커버하므로
 -- (leftmost prefix) user_id 단독 인덱스는 두지 않는다.
 
+-- 테이블 권한(GRANT): Supabase가 2026-05-30부터 새 테이블의 자동 노출
+-- (anon/authenticated/service_role 자동 GRANT)을 폐기 중이라 명시가 필수다
+-- (미부여 시 RLS 이전 단계에서 "permission denied for table"로 거부된다).
+-- row 접근 통제는 아래 RLS가 담당한다 — "GRANT로 열고 RLS로 잠근다".
+GRANT SELECT, INSERT, UPDATE, DELETE ON push_preferences
+  TO anon, authenticated, service_role;
+GRANT SELECT, INSERT, UPDATE, DELETE ON push_subscriptions
+  TO anon, authenticated, service_role;
+
 -- updated_at 자동 갱신 (00001의 update_updated_at() 재사용)
 CREATE TRIGGER push_preferences_updated_at
   BEFORE UPDATE ON push_preferences


### PR DESCRIPTION
## Summary

9-c 실환경 검증 중 발견한 `permission denied for table push_preferences` 이슈의 재발 방지 백필입니다. 원인은 Supabase가 2026-05-30부터 새 테이블 자동 GRANT(anon/authenticated/service_role)를 폐기 중인 것 — RLS 정책이 전부 정상이어도 테이블 레벨 GRANT가 없으면 그 이전 단계에서 거부됩니다. 실DB에는 GRANT를 직접 적용해 해소했고, 이 PR은 마이그레이션 파일 정합성과 문서를 맞춥니다.

## 주요 변경 사항

### 1. 마이그레이션 GRANT 백필 (`2149fed`)

- `00002_create_push_subscriptions.sql`: 두 테이블에 `GRANT SELECT, INSERT, UPDATE, DELETE ... TO anon, authenticated, service_role` 명시 ("GRANT로 열고 RLS로 잠근다")
- 다른 환경에서 파일 재적용 시 같은 문제 예방

### 2. RLS 학습 문서 보강 + HANDOFF 갱신 (`3a95b10`)

- `step9b-supabase-rls.md`: 새 §2 "GRANT — RLS보다 한 층 아래에 문이 하나 더 있다" — 두 층의 증상 차이(명시적 permission denied vs 조용히 없는 row), Supabase 정책 변경 시점, 진단 쿼리, 실사례
- `HANDOFF.md`: 외부 선결 3종 완료 + 실환경 수동 검증 성공(로그인 → 구독 → 크롤 트리거 → 알림 수신) 반영, 다음 할 일을 9-d 착수 가능 상태로 갱신. 검증 중 해소한 이슈 2건(Redirect URLs globstar 교체, GRANT 부재) 기록

## 참고 사항

- 관련 이슈: #39
- 근거: [Supabase Breaking Change: Tables not exposed automatically](https://supabase.com/changelog/45329-breaking-change-tables-not-exposed-to-data-and-graphql-api-automatically)
- 코드(TS) 변경 없음 — 테스트 영향 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)