### PR TITLE
test: 구독/해제 E2E + RLS 소유권 거부 검증 (#39, Step 9-d-b)

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -5,7 +5,7 @@
 
 ---
 
-## 0. 최신 상태 (2026-07-20 기준)
+## 0. 최신 상태 (2026-07-22 기준)
 
 ### 진행 중 — Sprint 2 웹 푸시 알림 (#39) + 소셜 로그인 신규 편입
 
@@ -19,32 +19,35 @@ Sprint 2 1번 작업(웹 푸시 파이프라인, #39)을 Step(9-a~d)으로 쪼�
 
 **외부 선결 완료 + 실환경 수동 검증 성공**(2026-07-20): 외부 선결 3종(OAuth 콘솔·provider 설정 / 00002 마이그레이션 적용 / VAPID env 로컬·Vercel 주입) 모두 완료. 카카오 이메일(account_email)은 **비즈 앱 전용 권한**이라 동의항목에서 제외하고 Supabase Kakao provider의 **"Allow users without an email"** 로 대응 — 파이프라인은 email이 아닌 `user_id` 기준이라 영향 없음(이메일 알림 도입 시 카카오 사용자는 수신 주소 부재 유의). 검증: 로컬에서 구글 로그인 → 구독 토글 ON(L1·L2 row 생성 확인) → `last_board_id` 하향 후 크롤 트리거 → `push: {sent: 1}` + Chrome 알림 수신까지 **MVP 핵심 경로 관통 확인**. 이 과정에서 두 이슈를 밟고 해소: ① Supabase Redirect URLs를 경로 고정형에서 **globstar(`/**`)로 교체**(쿼리 파라미터 붙는 redirectTo가 매칭 실패 → Site URL 루트로 낙하하던 문제), ② **Supabase의 새 테이블 자동 GRANT 폐기**(2026-05-30~)로 `permission denied for table` — GRANT 명시로 해소, 마이그레이션 파일 백필 + RLS 학습 문서 §2 보강(이 커밋).
 
+**9-d 착수·9-d-a 완료·머지**(2026-07-22, PR #61): E2E 자동화 범위를 **"소유 표면"으로 한정**하는 전략을 ADR 010으로 확정하고 9-d-a/b/c로 분할. 9-d-a는 실 OAuth를 우회하는 Playwright **세션 주입 하네스**(admin 유저 생성 + `signInWithPassword` → `@supabase/ssr` 쿠키 캡처 → storageState) + **전용 테스트 Supabase 프로젝트**(마이그레이션 00001·00002 적용, OAuth provider 불필요) + 구독 **게이팅 스펙**(e2e 4/4). 실 OAuth·실 `pushManager.subscribe` FCM 구독·실 FCM 배달/팝업은 자동화 경계 밖(수동 스모크 유지, ADR 010). 다음은 9-d-b(구독/해제 → 실 DB row + RLS 거부).
+
 ### ✅ 해소됨 — 크롤 파이프라인 동결 (Issue #42, 2026-06-18)
 
 매시간 HTTP 500으로 동결됐던 크롤 파이프라인을 PR #45로 해소(프로덕션 500→200, DB 저장 검증). 근본 원인(boardId가 여러 게시판이 공유하는 전역 시퀀스 → gap-fill이 타 게시판 불량 row를 끌어와 배치 upsert 전체 실패)과 수정(gap-fill 폐기 → 목록 기반 크롤 전환)은 **ADR 007** 및 `docs/troubleshooting/2026-06-09-cron-bootstrap-catch-up.md`에 상세.
 
 ### 완료된 Step
 
-| Step           | 내용                                                                                                                                                                                                | 근거·산출물                                                                                         |
-| -------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------- |
-| Step 2         | Next.js 초기화, Prettier/husky/lint-staged, Vitest/Playwright                                                                                                                                       | `learning/step2-essentials`                                                                         |
-| Step 3         | Vercel 연동 + GitHub Actions CI (lint·tsc·test)                                                                                                                                                     | `learning/step3-ci-setup`                                                                           |
-| Step 4         | 크롤 파서 + DB 스키마 + 타입                                                                                                                                                                        | `learning/step4-{cheerio,vitest-basics,db-basics}` (※ `parseMainPage`·`checkBoardId`는 Step 6 폐기) |
-| Step 5-a~d     | fetch+retry / rateLimit / `announcementService` 합성 / MSW 통합테스트                                                                                                                               | `learning/step5-{fetch-html,retry,rate-limit,msw-testing}`                                          |
-| Step 6         | 데이터 소스 재설계: JSON 목록(주) + view.do 하이브리드 (epic #19)                                                                                                                                   | ADR 002/003; PR #20~23·#25                                                                          |
-| Step 6 정리    | `checkBoardId` 모듈 실제 삭제 + 이슈 본문 정리                                                                                                                                                      | PR #27                                                                                              |
-| Step 7         | Supabase 저장 통합: admin 클라 + `announcements` UPSERT + `crawl_state` 리포                                                                                                                        | `learning/step7-*`; PR #29·#30                                                                      |
-| Step 8         | 크롤 스케줄러: `/api/cron/crawl` + `crawl.yml` (1h cron + dispatch), `CRON_SECRET` 인증                                                                                                             | ADR 004; `learning/step8-gha-cron-vercel-trigger`; PR #35                                           |
-| Step 8 픽스    | 부트스트랩 catch-up 루프 픽스 — 시드 0이면 latestBoardId만 저장 (#36)                                                                                                                               | ADR 005; `troubleshooting/2026-06-09-cron-bootstrap-catch-up`                                       |
-| 크롤 동결 픽스 | 동결 해소 (#42): gap-fill 폐기 → 목록 기반 크롤, 페이지네이션 보전, row별 격리. 프로덕션 500→200 검증                                                                                               | ADR 007; PR #43·#45                                                                                 |
-| Step 9-a       | 웹 푸시 구독 클라 경로 (#39): VAPID 유틸 + SW 등록 + `usePushSubscription` 훅 + 임시 `/subscribe` UI. Chrome E2E 검증                                                                               | PR #47 (서버 저장 9-b·발송 9-c)                                                                     |
-| Step 50-a      | 소셜 로그인 SSR 기반 (#50): `@supabase/ssr` browser/server 클라 + 세션 미들웨어 + OAuth 콜백 라우트. typecheck/lint/96 tests (정적·단위)                                                            | ADR 009; PR #52 (로그인 UI·게이팅 50-b)                                                             |
-| Step 50-b      | 소셜 로그인 UI + 구독 게이팅 (#50): 구글·카카오 로그인/로그아웃 + `/subscribe` 게이팅 + `signInWithProvider`·`getSessionUser`. 103 tests (정적·단위, E2E는 외부 OAuth 설정 후)                      | ADR 009; PR #53; `learning/step50-supabase-ssr-auth`                                                |
-| Step 9-b       | 웹 푸시 구독 저장 (#39): L1/L2 분리 스키마(`push_preferences`/`push_subscriptions`, `UNIQUE(user_id, endpoint)`, RLS) + `POST/DELETE /api/push/subscribe` + 구독 토글 UI·마운트 재동기화. 132 tests | ADR 008(2차 재작성); PR #55; `learning/step9b-supabase-rls`                                         |
-| Step 9-c       | 웹 푸시 발송 (#39): 크롤 신규 감지 → L1 `enabled` 계정의 L2 채널 발송(`web-push`) + `410`/`404` 만료 채널 정리 + 크롤 응답에 `push` 집계(발송 실패에도 200 유지). 162 tests                         | ADR 008; PR #58; `learning/step9-web-push`                                                          |
-| 운영·회고      | Sprint 1 운영 검증 (GHA dispatch 2회 success, `last_board_id` 6561 갱신) + Sprint 1 회고                                                                                                            | `retrospectives/sprint-1`                                                                           |
+| Step           | 내용                                                                                                                                                                                                                       | 근거·산출물                                                                                         |
+| -------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------- |
+| Step 2         | Next.js 초기화, Prettier/husky/lint-staged, Vitest/Playwright                                                                                                                                                              | `learning/step2-essentials`                                                                         |
+| Step 3         | Vercel 연동 + GitHub Actions CI (lint·tsc·test)                                                                                                                                                                            | `learning/step3-ci-setup`                                                                           |
+| Step 4         | 크롤 파서 + DB 스키마 + 타입                                                                                                                                                                                               | `learning/step4-{cheerio,vitest-basics,db-basics}` (※ `parseMainPage`·`checkBoardId`는 Step 6 폐기) |
+| Step 5-a~d     | fetch+retry / rateLimit / `announcementService` 합성 / MSW 통합테스트                                                                                                                                                      | `learning/step5-{fetch-html,retry,rate-limit,msw-testing}`                                          |
+| Step 6         | 데이터 소스 재설계: JSON 목록(주) + view.do 하이브리드 (epic #19)                                                                                                                                                          | ADR 002/003; PR #20~23·#25                                                                          |
+| Step 6 정리    | `checkBoardId` 모듈 실제 삭제 + 이슈 본문 정리                                                                                                                                                                             | PR #27                                                                                              |
+| Step 7         | Supabase 저장 통합: admin 클라 + `announcements` UPSERT + `crawl_state` 리포                                                                                                                                               | `learning/step7-*`; PR #29·#30                                                                      |
+| Step 8         | 크롤 스케줄러: `/api/cron/crawl` + `crawl.yml` (1h cron + dispatch), `CRON_SECRET` 인증                                                                                                                                    | ADR 004; `learning/step8-gha-cron-vercel-trigger`; PR #35                                           |
+| Step 8 픽스    | 부트스트랩 catch-up 루프 픽스 — 시드 0이면 latestBoardId만 저장 (#36)                                                                                                                                                      | ADR 005; `troubleshooting/2026-06-09-cron-bootstrap-catch-up`                                       |
+| 크롤 동결 픽스 | 동결 해소 (#42): gap-fill 폐기 → 목록 기반 크롤, 페이지네이션 보전, row별 격리. 프로덕션 500→200 검증                                                                                                                      | ADR 007; PR #43·#45                                                                                 |
+| Step 9-a       | 웹 푸시 구독 클라 경로 (#39): VAPID 유틸 + SW 등록 + `usePushSubscription` 훅 + 임시 `/subscribe` UI. Chrome E2E 검증                                                                                                      | PR #47 (서버 저장 9-b·발송 9-c)                                                                     |
+| Step 50-a      | 소셜 로그인 SSR 기반 (#50): `@supabase/ssr` browser/server 클라 + 세션 미들웨어 + OAuth 콜백 라우트. typecheck/lint/96 tests (정적·단위)                                                                                   | ADR 009; PR #52 (로그인 UI·게이팅 50-b)                                                             |
+| Step 50-b      | 소셜 로그인 UI + 구독 게이팅 (#50): 구글·카카오 로그인/로그아웃 + `/subscribe` 게이팅 + `signInWithProvider`·`getSessionUser`. 103 tests (정적·단위, E2E는 외부 OAuth 설정 후)                                             | ADR 009; PR #53; `learning/step50-supabase-ssr-auth`                                                |
+| Step 9-b       | 웹 푸시 구독 저장 (#39): L1/L2 분리 스키마(`push_preferences`/`push_subscriptions`, `UNIQUE(user_id, endpoint)`, RLS) + `POST/DELETE /api/push/subscribe` + 구독 토글 UI·마운트 재동기화. 132 tests                        | ADR 008(2차 재작성); PR #55; `learning/step9b-supabase-rls`                                         |
+| Step 9-c       | 웹 푸시 발송 (#39): 크롤 신규 감지 → L1 `enabled` 계정의 L2 채널 발송(`web-push`) + `410`/`404` 만료 채널 정리 + 크롤 응답에 `push` 집계(발송 실패에도 200 유지). 162 tests                                                | ADR 008; PR #58; `learning/step9-web-push`                                                          |
+| Step 9-d-a     | 웹 푸시 E2E 인증 하네스 (#39): Playwright 세션 주입(admin 유저 + `signInWithPassword` → `@supabase/ssr` 쿠키 → storageState, 실 OAuth 우회) + 전용 테스트 Supabase 프로젝트 + `.env.test` 주입 + 구독 게이팅 스펙. e2e 4/4 | ADR 010; PR #61                                                                                     |
+| 운영·회고      | Sprint 1 운영 검증 (GHA dispatch 2회 success, `last_board_id` 6561 갱신) + Sprint 1 회고                                                                                                                                   | `retrospectives/sprint-1`                                                                           |
 
-> ADR 전체: `docs/adr/` — 001 기술스택, 002/003 데이터소스·매핑, 004 스케줄러, 005 부트스트랩, 006 크롤 출력 검증, 007 크롤 범위, 008 구독 저장 모델(구독 의사/배달 채널 분리), 009 소셜 로그인.
+> ADR 전체: `docs/adr/` — 001 기술스택, 002/003 데이터소스·매핑, 004 스케줄러, 005 부트스트랩, 006 크롤 출력 검증, 007 크롤 범위, 008 구독 저장 모델(구독 의사/배달 채널 분리), 009 소셜 로그인, 010 E2E 테스트 전략(소유 표면 자동화 + 실 OAuth·FCM 경계).
 
 ### Sprint 1 완료 — 다음 Sprint 2 시작 준비
 
@@ -56,7 +59,10 @@ Sprint 2 1번 작업(웹 푸시 파이프라인, #39)을 Step(9-a~d)으로 쪼�
 
 웹 푸시 파이프라인 (#39) 남은 Step:
 
-- 9-d (다음): Playwright E2E (로그인 → 구독 → 신규 공고 → 알림 수신). 수동으로 검증한 경로의 자동화.
+- 9-d: Playwright E2E — 수동 검증 경로의 자동화. **소유 표면만 자동화**하고 실 OAuth·실 FCM 배달은 수동 스모크로 유지(ADR 010). 3분할:
+  - 9-d-a ✅ 완료·머지(PR #61): 세션 주입 하네스(실 OAuth 우회) + 전용 테스트 Supabase 프로젝트 + 구독 게이팅 스펙.
+  - 9-d-b (진행 중): 구독/해제 E2E(합성 구독 → 실 DB row) + RLS 남의 row 거부.
+  - 9-d-c: 발송 절반(Vitest+MSW: 신규 감지 → 발송 집계) + GHA e2e job 편입 + 학습 문서(step9d).
 
 운영 참고: VAPID 키 쌍은 로테이션하면 기존 구독이 전부 무효가 되므로 한 번 만들면 유지한다(`learning/step9-web-push` §2).
 

--- a/e2e/helpers/pushStub.ts
+++ b/e2e/helpers/pushStub.ts
@@ -1,0 +1,51 @@
+/**
+ * 브라우저 푸시 구독 합성 스텁 (ADR 010).
+ *
+ * headless Chromium에서 실 FCM 구독 생성(`pushManager.subscribe`)은 푸시 서비스가
+ * 없어 비결정적으로 실패한다. `PushManager.prototype`만 합성 구독으로 스텁해 구독
+ * 생성 단계만 결정론적으로 만든다 — 실제 SW 등록·버튼 클릭·`POST /api/push/subscribe`·
+ * RLS·DB 쓰기는 모두 진짜로 일어난다(소유 표면 검증). 실 구독 생성 경로 자체는
+ * 자동화 경계 밖(수동 스모크).
+ */
+
+import type { BrowserContext, Page } from '@playwright/test';
+
+/** 합성 구독의 고정 값 — 실제 FCM endpoint 형식을 흉내낸다(저장/조회 검증용). */
+export const FAKE_SUBSCRIPTION = {
+  endpoint: 'https://fcm.googleapis.com/fcm/send/e2e-fake-channel-0001',
+  expirationTime: null,
+  keys: {
+    p256dh:
+      'BEl62iUYgUivxIkv69yViEuiBIa-Ib9-SkvMeAtA3LFgDzkrxZJjSgSnfckjBJuBkr3qBUYIHBQFLXYp5Nksh8',
+    auth: 'e2e-fake-auth-secret',
+  },
+} as const;
+
+/**
+ * notifications 권한을 부여하고, `PushManager.prototype.subscribe/getSubscription`을
+ * 합성 구독으로 스텁한다. goto 전에 호출해야 한다(addInitScript는 다음 내비게이션부터 적용).
+ */
+export async function stubPushSubscription(
+  context: BrowserContext,
+  page: Page,
+): Promise<void> {
+  await context.grantPermissions(['notifications']);
+  await page.addInitScript((sub) => {
+    if (!('PushManager' in window)) return;
+    const fake = {
+      endpoint: sub.endpoint,
+      expirationTime: null,
+      toJSON: () => sub,
+      unsubscribe: async () => true,
+    };
+    Object.defineProperty(PushManager.prototype, 'subscribe', {
+      configurable: true,
+      value: async () => fake,
+    });
+    // 시작 시엔 기존 구독 없음 — 클릭으로 생성되는 경로를 검증한다.
+    Object.defineProperty(PushManager.prototype, 'getSubscription', {
+      configurable: true,
+      value: async () => null,
+    });
+  }, FAKE_SUBSCRIPTION);
+}

--- a/e2e/helpers/testUser.ts
+++ b/e2e/helpers/testUser.ts
@@ -19,6 +19,12 @@ export const TEST_USER = {
   password: 'e2e-password-1234!',
 } as const;
 
+/** RLS 남의 row 거부 검증용 2번째 계정. */
+export const SECOND_USER = {
+  email: 'e2e-other@cheong-an.test',
+  password: 'e2e-other-1234!',
+} as const;
+
 export interface TestSupabaseEnv {
   url: string;
   serviceRoleKey: string;
@@ -50,41 +56,105 @@ export function getAdminClient(): SupabaseClient {
   });
 }
 
-/** 이메일로 기존 테스트 유저를 찾는다(없으면 null). */
-async function findTestUser(admin: SupabaseClient): Promise<string | null> {
+/** 이메일로 기존 유저 id를 찾는다(없으면 null). */
+async function findUserIdByEmail(
+  admin: SupabaseClient,
+  email: string,
+): Promise<string | null> {
   const { data, error } = await admin.auth.admin.listUsers();
   if (error) throw error;
-  const found = data.users.find((u) => u.email === TEST_USER.email);
+  const found = data.users.find((u) => u.email === email);
   return found?.id ?? null;
 }
 
 /**
- * 테스트 유저를 멱등 생성한다 — 이미 있으면 그대로 재사용하고 userId를 반환한다.
+ * 유저를 멱등 생성한다 — 이미 있으면 그대로 재사용하고 userId를 반환한다.
  * `email_confirm: true`로 이메일 확인을 건너뛴다(테스트 프로젝트는 provider 설정 없음).
  */
-export async function ensureTestUser(): Promise<string> {
+export async function ensureUser(
+  email: string,
+  password: string,
+): Promise<string> {
   const admin = getAdminClient();
 
   const { data, error } = await admin.auth.admin.createUser({
-    email: TEST_USER.email,
-    password: TEST_USER.password,
+    email,
+    password,
     email_confirm: true,
   });
 
   if (!error && data.user) return data.user.id;
 
   // 이미 존재하는 경우만 조회로 폴백한다. 그 외 오류는 그대로 표면화.
-  const existing = await findTestUser(admin);
+  const existing = await findUserIdByEmail(admin, email);
   if (existing) return existing;
 
   throw new Error(
-    `테스트 유저 생성/조회 실패: ${error?.message ?? '알 수 없는 오류'}`,
+    `테스트 유저 생성/조회 실패(${email}): ${error?.message ?? '알 수 없는 오류'}`,
   );
 }
 
-/** 테스트 유저를 삭제한다(FK CASCADE로 push_preferences/subscriptions도 정리됨). */
-export async function deleteTestUser(): Promise<void> {
+/** 주 테스트 유저를 멱등 생성한다(global.setup 세션 주입 대상). */
+export function ensureTestUser(): Promise<string> {
+  return ensureUser(TEST_USER.email, TEST_USER.password);
+}
+
+/** 유저를 삭제한다(FK CASCADE로 push_preferences/subscriptions도 정리됨). */
+export async function deleteUser(email: string): Promise<void> {
   const admin = getAdminClient();
-  const existing = await findTestUser(admin);
+  const existing = await findUserIdByEmail(admin, email);
   if (existing) await admin.auth.admin.deleteUser(existing);
+}
+
+/** 한 유저의 구독 데이터(L1/L2)를 admin으로 모두 지운다 — 테스트 멱등성 확보용. */
+export async function clearPushData(userId: string): Promise<void> {
+  const admin = getAdminClient();
+  await admin.from('push_subscriptions').delete().eq('user_id', userId);
+  await admin.from('push_preferences').delete().eq('user_id', userId);
+}
+
+/** L1 구독 의사 row(없으면 null). admin(RLS 우회)로 조회. */
+export async function getPushPreferenceRow(
+  userId: string,
+): Promise<{ enabled: boolean } | null> {
+  const admin = getAdminClient();
+  const { data, error } = await admin
+    .from('push_preferences')
+    .select('enabled')
+    .eq('user_id', userId)
+    .maybeSingle();
+  if (error) throw error;
+  return data;
+}
+
+/** L2 배달 채널 rows. admin(RLS 우회)로 조회. */
+export async function getPushSubscriptionRows(
+  userId: string,
+): Promise<{ endpoint: string }[]> {
+  const admin = getAdminClient();
+  const { data, error } = await admin
+    .from('push_subscriptions')
+    .select('endpoint')
+    .eq('user_id', userId);
+  if (error) throw error;
+  return data ?? [];
+}
+
+/**
+ * 세션 바인딩 anon 클라이언트 — 지정 유저로 로그인해 RLS가 적용되는 상태를
+ * 만든다(admin과 달리 RLS 우회 안 함). 남의 row 거부 검증에 쓴다.
+ */
+export async function createSessionClient(
+  email: string,
+  password: string,
+): Promise<SupabaseClient> {
+  const { url, anonKey } = getTestSupabaseEnv();
+  const client = createClient(url, anonKey, {
+    auth: { persistSession: false, autoRefreshToken: false },
+  });
+  const { error } = await client.auth.signInWithPassword({ email, password });
+  if (error) {
+    throw new Error(`세션 클라 로그인 실패(${email}): ${error.message}`);
+  }
+  return client;
 }

--- a/e2e/subscribe.spec.ts
+++ b/e2e/subscribe.spec.ts
@@ -1,0 +1,111 @@
+/**
+ * 구독/해제 E2E + RLS 소유권 검증 (9-d-b, ADR 008/010).
+ *
+ * 합성 구독(pushStub)으로 브라우저 구독 생성만 결정론화하고, 클릭 이후의
+ * POST /api/push/subscribe → 세션 바인딩 server 클라 → RLS → 실 DB 쓰기는
+ * 진짜로 일어나는 것을 admin 조회로 검증한다. 마지막으로 RLS가 남의 row를
+ * 실제로 가리는지(정책 실효성, step9b-supabase-rls §7)를 확인한다.
+ */
+
+import { expect, test } from '@playwright/test';
+
+import { FAKE_SUBSCRIPTION, stubPushSubscription } from './helpers/pushStub';
+import {
+  clearPushData,
+  createSessionClient,
+  ensureTestUser,
+  ensureUser,
+  getAdminClient,
+  getPushPreferenceRow,
+  getPushSubscriptionRows,
+  SECOND_USER,
+  TEST_USER,
+} from './helpers/testUser';
+
+test.describe('구독/해제 (합성 구독 → 실 DB)', () => {
+  let userId: string;
+
+  test.beforeAll(async () => {
+    userId = await ensureTestUser();
+  });
+
+  test.beforeEach(async () => {
+    // 이전 실행 잔여 제거 — 반복 실행 멱등성.
+    await clearPushData(userId);
+  });
+
+  test('구독 클릭 → L2 채널 + L1 enabled=true, 해제 → enabled=false(L2 보존)', async ({
+    context,
+    page,
+  }) => {
+    await stubPushSubscription(context, page);
+
+    await page.goto('/subscribe');
+    await expect(page.getByText('계정 구독 상태')).toBeVisible();
+
+    // 구독: POST 201
+    const postResp = page.waitForResponse(
+      (r) =>
+        r.url().includes('/api/push/subscribe') &&
+        r.request().method() === 'POST',
+    );
+    await page.getByRole('button', { name: '알림 구독' }).click();
+    expect((await postResp).status()).toBe(201);
+    await expect(page.getByText('구독 중')).toBeVisible();
+
+    // 실 DB: L2 채널 1건(합성 endpoint) + L1 enabled=true
+    const subs = await getPushSubscriptionRows(userId);
+    expect(subs).toHaveLength(1);
+    expect(subs[0].endpoint).toBe(FAKE_SUBSCRIPTION.endpoint);
+    expect(await getPushPreferenceRow(userId)).toMatchObject({ enabled: true });
+
+    // 해제: DELETE 200 → L1 enabled=false, L2는 보존 (ADR 008)
+    const deleteResp = page.waitForResponse(
+      (r) =>
+        r.url().includes('/api/push/subscribe') &&
+        r.request().method() === 'DELETE',
+    );
+    await page.getByRole('button', { name: '알림 해제 (모든 기기)' }).click();
+    expect((await deleteResp).status()).toBe(200);
+
+    expect(await getPushPreferenceRow(userId)).toMatchObject({
+      enabled: false,
+    });
+    expect(await getPushSubscriptionRows(userId)).toHaveLength(1);
+  });
+});
+
+test.describe('RLS — 남의 row는 보이지 않는다', () => {
+  test('userA 세션은 userB의 push_preferences를 조회하지 못한다(에러 아님)', async () => {
+    await ensureTestUser();
+    const userBId = await ensureUser(SECOND_USER.email, SECOND_USER.password);
+
+    // userB의 L1 row를 admin(RLS 우회)으로 심는다.
+    const admin = getAdminClient();
+    await admin
+      .from('push_preferences')
+      .upsert({ user_id: userBId, enabled: true }, { onConflict: 'user_id' });
+
+    // 대조군: admin은 userB row가 보인다.
+    expect(await getPushPreferenceRow(userBId)).toMatchObject({
+      enabled: true,
+    });
+
+    // userA 세션 anon 클라는 userB row가 "없는 것처럼" 보인다 — 권한 에러가
+    // 아니라 빈 결과여야 RLS가 정상 동작하는 것이다(step9b-supabase-rls §1).
+    const asUserA = await createSessionClient(
+      TEST_USER.email,
+      TEST_USER.password,
+    );
+    const { data, error } = await asUserA
+      .from('push_preferences')
+      .select('*')
+      .eq('user_id', userBId);
+
+    expect(error).toBeNull();
+    expect(data).toEqual([]);
+
+    // 정리.
+    await admin.from('push_preferences').delete().eq('user_id', userBId);
+  });
+});


### PR DESCRIPTION
## Summary

웹 푸시 E2E(#39, Step 9-d) 두 번째 단위 **9-d-b**. 합성 구독으로 브라우저 구독 생성만 결정론화하고, 그 이후 **POST/DELETE → 세션 바인딩 server 클라 → RLS → 실 DB 쓰기**를 진짜로 검증한다. 마지막으로 RLS가 남의 row를 실제로 가리는지(정책 실효성)를 확인한다. 전략 근거는 ADR 010.

## 주요 변경 사항

### 1. 구독/해제 E2E (합성 구독 → 실 DB)

- `e2e/helpers/pushStub.ts`: `context.grantPermissions(['notifications'])` + `PushManager.prototype.subscribe/getSubscription`을 고정 endpoint/keys의 합성 구독으로 스텁(headless FCM 구독 생성의 비결정성 회피). 실제 SW 등록·클릭·POST·RLS·DB 쓰기는 진짜로 일어난다.
- `e2e/subscribe.spec.ts`: 알림 구독 클릭 → POST **201** → admin 조회로 L2 채널 1건 + L1 `enabled=true` 검증. 해제 → DELETE **200** → L1 `enabled=false`, **L2 보존**(ADR 008).

### 2. RLS 소유권 거부

- userB의 `push_preferences` row를 admin(RLS 우회)으로 심고, **userA 세션 anon 클라**로 조회 시 권한 에러가 아니라 **빈 결과**임을 확인(step9b-supabase-rls §1·§7의 "정책 실효성은 실 DB E2E" 담당).

### 3. 헬퍼 확장

- `e2e/helpers/testUser.ts`: `ensureUser(email,pw)` 일반화 + `SECOND_USER` + `clearPushData`(멱등성) + `getPushPreferenceRow`/`getPushSubscriptionRows`(admin 조회) + `createSessionClient`(세션 바인딩 anon 클라).

### 4. HANDOFF 갱신 (docs 커밋 분리)

- `0. 최신 상태`: 9-d-a 완료·머지(#61) 반영 + 9-d 3분할(9-d-a/b/c) + ADR 010 등재. (별도 `docs:` 커밋)

## 참고 사항

- 로컬 검증: `pnpm test:e2e` **6/6 통과**(setup + 게이팅 2 + 구독/해제 + RLS). typecheck·lint 통과.
- 이 PR의 CI(`ci.yml`)는 여전히 lint·tsc·unit만 실행(e2e 미실행). **e2e의 CI 편입은 9-d-c**에서 테스트 Supabase secret 주입과 함께.
- 남은 Step: 9-d-c(발송 절반 Vitest+MSW + GHA e2e job + 학습 문서 step9d).