### PR TITLE
fix: optn5 미기재 공고 제목 폴백 — 목록 파서 전면 실패 해소 (#68)

### DIFF
--- a/src/lib/crawler/parseListJson.test.ts
+++ b/src/lib/crawler/parseListJson.test.ts
@@ -111,6 +111,69 @@ describe('parseListJson', () => {
     expect(() => parseListJson(bad)).toThrow(ParseListJsonError);
   });
 
+  it('optn5가 null이면 제목으로 폴백한다 — 추가모집 미포함은 initial (#68, boardId 6624 재현)', () => {
+    const missing = JSON.stringify({
+      resultList: [
+        {
+          boardId: 6624,
+          nttSj: '[공공임대] 2026년 2차 청년안심주택 모집공고',
+          content: '',
+          optn1: '',
+          optn2: '1',
+          optn3: '',
+          optn4: '',
+          optn5: null,
+          atchFileId: '',
+          regDate: 0,
+        },
+      ],
+    });
+    const [item] = parseListJson(missing);
+    expect(item.recruitmentType).toBe('initial');
+  });
+
+  it('optn5가 null이고 제목에 추가모집이 있으면 additional로 폴백한다', () => {
+    const missing = JSON.stringify({
+      resultList: [
+        {
+          boardId: 1,
+          nttSj: '[민간임대] 어딘가역 추가모집공고',
+          content: '',
+          optn1: '',
+          optn2: '2',
+          optn3: '',
+          optn4: '',
+          optn5: null,
+          atchFileId: '',
+          regDate: 0,
+        },
+      ],
+    });
+    const [item] = parseListJson(missing);
+    expect(item.recruitmentType).toBe('additional');
+  });
+
+  it('optn5가 빈 문자열이어도 제목 폴백을 태운다', () => {
+    const blank = JSON.stringify({
+      resultList: [
+        {
+          boardId: 1,
+          nttSj: 'X',
+          content: '',
+          optn1: '',
+          optn2: '1',
+          optn3: '',
+          optn4: '',
+          optn5: '  ',
+          atchFileId: '',
+          regDate: 0,
+        },
+      ],
+    });
+    const [item] = parseListJson(blank);
+    expect(item.recruitmentType).toBe('initial');
+  });
+
   it('잘못된 JSON은 ParseListJsonError로 던진다', () => {
     expect(() => parseListJson('not json')).toThrow(ParseListJsonError);
   });

--- a/src/lib/crawler/parseListJson.ts
+++ b/src/lib/crawler/parseListJson.ts
@@ -100,7 +100,7 @@ function toListItem(
     boardId: item.boardId,
     title: item.nttSj.trim(),
     announcementType: toAnnouncementType(item.optn2, index),
-    recruitmentType: toRecruitmentType(item.optn5, index),
+    recruitmentType: toRecruitmentType(item.optn5, item.nttSj, index),
     agency: nullIfEmpty(item.optn3),
     postDate: toKstDateString(item.regDate),
     applicationStartDate: nullIfEmpty(item.optn1),
@@ -123,12 +123,20 @@ function toAnnouncementType(
 
 function toRecruitmentType(
   value: string | null,
+  title: string,
   index: number,
 ): RecruitmentType {
   if (value === '1') return 'initial';
   if (value === '2') return 'additional';
+  // 미기재(null/빈 값)는 실측된 상태다 — boardId 6624(2026-08, 공공임대)가
+  // optn5 없이 게시돼 크롤이 동결됐다(#68). parseDetailPage와 동일한 제목
+  // 휴리스틱으로 폴백한다. 미기재가 아닌 미지의 코드는 분류 체계 변경
+  // 신호이므로 기존대로 throw해 카나리가 잡게 한다.
+  if (value == null || value.trim() === '') {
+    return title.includes('추가모집') ? 'additional' : 'initial';
+  }
   throw new ParseListJsonError(
-    `resultList[${index}].optn5: unknown recruitment type code "${value ?? ''}"`,
+    `resultList[${index}].optn5: unknown recruitment type code "${value}"`,
   );
 }
 


### PR DESCRIPTION
## Summary

2026-08-03 게시된 boardId 6624(「[공공임대] 2026년 2차 청년안심주택 모집공고」)가 `optn5`(모집유형 코드)를 `null`로 달고 올라와 `toRecruitmentType`이 throw → 목록 전체 파싱 중단 → 카나리·본 크롤 경로 모두 실패로 `/api/cron/crawl`이 08-03 08:31 UTC부터 매시간 500. 미기재 값에 제목 폴백을 추가해 동결을 해소한다.

Closes #68

## 주요 변경 사항

### 1. `parseListJson.toRecruitmentType` 제목 폴백

- `optn5`가 `null`/빈 문자열이면 `parseDetailPage`와 동일한 제목 휴리스틱으로 폴백: `'추가모집'` 포함 → `additional`, 아니면 `initial` (6624는 `initial`)
- `'1'`/`'2'`는 기존대로 코드 우선. **미기재가 아닌 미지의 코드(`'9'` 등)는 기존대로 throw 유지** — 분류 체계 변경을 카나리가 계속 감지하도록 경계 보존
- DB `recruitment_type NOT NULL` 스키마·도메인 타입 무변경

### 2. 테스트 3건 추가

- 6624 재현 케이스: `optn5: null` + 일반 제목 → `initial`
- `optn5: null` + `'추가모집'` 제목 → `additional`
- 빈 문자열(`'  '`)도 폴백 경로를 태움

## 참고 사항

- 검증: 유닛 179/179, tsc·eslint 클린, **라이브 사이트 상대 카나리 재실행 → violations 0건** (수정 전엔 6624에서 throw)
- PR #66 배포와 실패 시점이 겹쳤으나 무관 — 외부 데이터 변화가 원인 (GHA cron 08-03 04:32 UTC까지 성공, #66 배포는 06:12 UTC, 첫 실패 08:31 UTC)
- 한 항목의 매핑 실패가 목록 전체를 죽이는 구조(ADR 007 row 격리 원칙과 상충)는 이번 폴백으로는 미해소 — 필요 시 후속 이슈로 분리
- 머지 후 GHA `Crawl` workflow dispatch로 프로덕션 500→200 및 6624 저장·발송 확인 필요

🤖 Generated with [Claude Code](https://claude.com/claude-code)