### PR TITLE
fix: optn2 미기재 공고 제목 폴백 — #68 쌍둥이 예방 (#71)

### DIFF
--- a/src/lib/crawler/parseListJson.test.ts
+++ b/src/lib/crawler/parseListJson.test.ts
@@ -111,6 +111,69 @@ describe('parseListJson', () => {
     expect(() => parseListJson(bad)).toThrow(ParseListJsonError);
   });
 
+  it('optn2가 null이면 제목으로 폴백한다 — 공공임대 포함은 public (#71)', () => {
+    const missing = JSON.stringify({
+      resultList: [
+        {
+          boardId: 1,
+          nttSj: '[공공임대] 2026년 3차 청년안심주택 모집공고',
+          content: '',
+          optn1: '',
+          optn2: null,
+          optn3: '',
+          optn4: '',
+          optn5: '1',
+          atchFileId: '',
+          regDate: 0,
+        },
+      ],
+    });
+    const [item] = parseListJson(missing);
+    expect(item.announcementType).toBe('public');
+  });
+
+  it('optn2가 null이고 제목에 공공임대가 없으면 private으로 폴백한다', () => {
+    const missing = JSON.stringify({
+      resultList: [
+        {
+          boardId: 1,
+          nttSj: '[민간임대] 어딘가역 최초모집공고',
+          content: '',
+          optn1: '',
+          optn2: null,
+          optn3: '',
+          optn4: '',
+          optn5: '1',
+          atchFileId: '',
+          regDate: 0,
+        },
+      ],
+    });
+    const [item] = parseListJson(missing);
+    expect(item.announcementType).toBe('private');
+  });
+
+  it('optn2가 빈 문자열이어도 제목 폴백을 태운다', () => {
+    const blank = JSON.stringify({
+      resultList: [
+        {
+          boardId: 1,
+          nttSj: 'X',
+          content: '',
+          optn1: '',
+          optn2: '  ',
+          optn3: '',
+          optn4: '',
+          optn5: '1',
+          atchFileId: '',
+          regDate: 0,
+        },
+      ],
+    });
+    const [item] = parseListJson(blank);
+    expect(item.announcementType).toBe('private');
+  });
+
   it('optn5가 null이면 제목으로 폴백한다 — 추가모집 미포함은 initial (#68, boardId 6624 재현)', () => {
     const missing = JSON.stringify({
       resultList: [

--- a/src/lib/crawler/parseListJson.ts
+++ b/src/lib/crawler/parseListJson.ts
@@ -99,7 +99,7 @@ function toListItem(
   return {
     boardId: item.boardId,
     title: item.nttSj.trim(),
-    announcementType: toAnnouncementType(item.optn2, index),
+    announcementType: toAnnouncementType(item.optn2, item.nttSj, index),
     recruitmentType: toRecruitmentType(item.optn5, item.nttSj, index),
     agency: nullIfEmpty(item.optn3),
     postDate: toKstDateString(item.regDate),
@@ -112,12 +112,19 @@ function toListItem(
 
 function toAnnouncementType(
   value: string | null,
+  title: string,
   index: number,
 ): AnnouncementType {
   if (value === '1') return 'public';
   if (value === '2') return 'private';
+  // #68(optn5 미기재 → 크롤 동결)의 쌍둥이 예방(#71). 미기재는 parseDetailPage와
+  // 동일한 제목 휴리스틱으로 폴백하고, 미지의 코드는 분류 체계 변경 신호이므로
+  // 기존대로 throw해 카나리가 잡게 한다.
+  if (value == null || value.trim() === '') {
+    return title.includes('공공임대') ? 'public' : 'private';
+  }
   throw new ParseListJsonError(
-    `resultList[${index}].optn2: unknown announcement type code "${value ?? ''}"`,
+    `resultList[${index}].optn2: unknown announcement type code "${value}"`,
   );
 }
 


### PR DESCRIPTION
## Summary

#68(optn5 미기재 → 크롤 전면 동결)과 동일한 클래스의 잠재 결함을 예방한다. `toAnnouncementType`은 `optn2`(공공/민간 코드)가 `'1'`/`'2'` 외 값이면 **null 포함** throw하므로, 같은 오입력이 이 필드에서 발생하면 목록 전체 파싱 중단 → 파이프라인 동결이 재발한다. PR #69와 대칭인 제목 폴백을 추가한다.

Closes #71

## 주요 변경 사항

### 1. `parseListJson.toAnnouncementType` 제목 폴백

- `optn2`가 `null`/빈 문자열이면 `parseDetailPage`와 동일한 제목 휴리스틱으로 폴백: `'공공임대'` 포함 → `public`, 아니면 `private`
- `'1'`/`'2'`는 기존대로 코드 우선. 미기재가 아닌 미지의 코드(`'9'` 등)는 기존대로 throw 유지 — 분류 체계 변경을 카나리가 계속 감지하도록 경계 보존
- PR #69(optn5 폴백)와 완전히 대칭인 구조

### 2. 테스트 3건 추가

- `optn2: null` + `'[공공임대]'` 제목 → `public`
- `optn2: null` + 공공임대 미포함 제목 → `private`
- 빈 문자열(`'  '`)도 폴백 경로를 태움

## 참고 사항

- 잠재 결함 예방(미발현) — 관측된 사고는 #68 참고
- 이 사이트 공고 제목은 `[공공임대]`/`[민간임대]` 접두가 관행이라 폴백 신뢰도 높음
- 구조적 해법(목록 파서 row 단위 격리)은 #72로 분리 — 이메일 채널(#65) 완료 후 착수
- 검증: 유닛 182/182, tsc·eslint 클린

🤖 Generated with [Claude Code](https://claude.com/claude-code)